### PR TITLE
Display parse errors in the response

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -92,7 +92,7 @@ func parseExpr(e string) (*expr, string, error) {
 	name, e := parseName(e)
 
 	if name == "" {
-		return nil, "", ErrMissingArgument
+		return nil, e, ErrMissingArgument
 	}
 
 	if e != "" && e[0] == '(' {
@@ -132,7 +132,7 @@ func parseArgList(e string) (string, []*expr, string, error) {
 		var err error
 		arg, e, err = parseExpr(e)
 		if err != nil {
-			return "", nil, "", err
+			return "", nil, e, err
 		}
 		args = append(args, arg)
 

--- a/main.go
+++ b/main.go
@@ -423,13 +423,26 @@ type renderStats struct {
 	zipperRequests int
 }
 
+func buildParseErrorString(target, e string, err error) string {
+	error_message := fmt.Sprintf("%s\n\n%-20s: %s\n", http.StatusText(http.StatusBadRequest), "Target", target)
+	if err != nil {
+		error_message += fmt.Sprintf("%-20s: %s\n", "Error", err.Error())
+	}
+	if e != "" {
+		error_message += fmt.Sprintf("%-20s: %s\n%-20s: %s\n",
+			"Parsed so far", target[0:len(target)-len(e)],
+			"Could not parse", e)
+	}
+	return error_message
+}
+
 func renderHandler(w http.ResponseWriter, r *http.Request, stats *renderStats) {
 
 	Metrics.Requests.Add(1)
 
 	err := r.ParseForm()
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		http.Error(w, http.StatusText(http.StatusBadRequest)+": "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -495,8 +508,10 @@ func renderHandler(w http.ResponseWriter, r *http.Request, stats *renderStats) {
 	for _, target := range targets {
 
 		exp, e, err := parseExpr(target)
+
 		if err != nil || e != "" {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			error_message := buildParseErrorString(target, e, err)
+			http.Error(w, error_message, http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
I'm trying to address here issue #28.

Example errors:

target=a%%
gives:
Bad Request: invalid URL escape "%%"

target=a""
gives:

Bad Request

Target              : a""
Parsed so far       : a
Could not parse     : ""

target=a(())
gives:

Bad Request

Target              : a(())
Error               : missing argument
Parsed so far       : a(
Could not parse     : ())