### PR TITLE
fix a bug on highestCurrent and similar expressions

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -1006,6 +1006,9 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 
 		for i, a := range arg {
 			m := compute(a.Values, a.IsAbsent)
+			if math.IsNaN(m) {
+				continue
+			}
 
 			if len(mh) < n {
 				heap.Push(&mh, metricHeapElement{idx: i, val: m})

--- a/expr_test.go
+++ b/expr_test.go
@@ -839,6 +839,7 @@ func TestEvalExpression(t *testing.T) {
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 0}: []*metricData{
+					makeResponse("metric0", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 					makeResponse("metricA", []float64{1, 1, 3, 3, 4, 12}, 1, now32),
 					makeResponse("metricB", []float64{1, 1, 3, 3, 4, 1}, 1, now32),
 					makeResponse("metricC", []float64{1, 1, 3, 3, 4, 15}, 1, now32),


### PR DESCRIPTION
highestCurrent and similar expressions didn't handle well a series where all elements are absent