### PR TITLE
Implementation of Pearson product-moment correlation coefficient (PMCC) function(s)

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -1605,6 +1605,136 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 		return results
 
+	case "pearson": // pearson(series, series, windowSize)
+		arg1, err := getSeriesArg(e.args[0], from, until, values)
+		if err != nil {
+			return nil
+		}
+
+		arg2, err := getSeriesArg(e.args[1], from, until, values)
+		if err != nil {
+			return nil
+		}
+
+		if len(arg1) != 1 || len(arg2) != 1 {
+			// must be single series
+			return nil
+		}
+
+		a1 := arg1[0]
+		a2 := arg2[0]
+
+		windowSize, err := getIntArg(e, 2)
+		if err != nil {
+			return nil
+		}
+
+		w1 := &Windowed{data: make([]float64, windowSize)}
+		w2 := &Windowed{data: make([]float64, windowSize)}
+
+		r := *a1
+		r.Name = proto.String(fmt.Sprintf("pearson(%s,%s,%d)", a1.GetName(), a2.GetName(), windowSize))
+		r.Values = make([]float64, len(a1.Values))
+		r.IsAbsent = make([]bool, len(a1.Values))
+		r.StartTime = proto.Int32(from)
+		r.StopTime = proto.Int32(until)
+
+		for i, v1 := range a1.Values {
+			v2 := a2.Values[i]
+			if a1.IsAbsent[i] || a2.IsAbsent[i] {
+				// ignore if either is missing
+				v1 = math.NaN()
+				v2 = math.NaN()
+			}
+			w1.Push(v1)
+			w2.Push(v2)
+			if i >= windowSize-1 {
+				r.Values[i] = onlinestats.Pearson(w1.data, w2.data)
+			} else {
+				r.Values[i] = 0
+				r.IsAbsent[i] = true
+			}
+		}
+
+		return []*metricData{&r}
+
+	case "pearsonClosest": // pearsonClosest(series, seriesList, n, direction=abs)
+		ref, err := getSeriesArg(e.args[0], from, until, values)
+		if err != nil {
+			return nil
+		}
+		if len(ref) != 1 {
+			// TODO(nnuss) error("First argument must be single reference series")
+			return nil
+		}
+
+		compare, err := getSeriesArg(e.args[1], from, until, values)
+		if err != nil {
+			return nil
+		}
+
+		n, err := getIntArg(e, 2)
+		if err != nil {
+			return nil
+		}
+
+		direction, err := getStringArgDefault(e, 3, "abs")
+		if err != nil && len(e.args) > 3 {
+			return nil
+		}
+		if direction != "pos" && direction != "neg" && direction != "abs" {
+			// TODO(nnuss) error("pearsonClosest( _ , _ , direction=abs ) : direction must be one of { 'pos', 'neg', 'abs' }")
+			return nil
+		}
+
+		// NOTE: if direction == "abs" && len(compare) <= n : we'll still do the work to rank them
+
+		for i, v := range ref[0].IsAbsent {
+			if v == true {
+				ref[0].Values[i] = math.NaN()
+			}
+		}
+
+		var mh metricHeap
+
+		for index, a := range compare {
+			if len(ref[0].Values) != len(a.Values) {
+				// Pearson will panic if arrays are not equal length; skip
+				continue
+			}
+			for i, v := range a.IsAbsent {
+				if v == true {
+					a.Values[i] = math.NaN()
+				}
+			}
+			value := onlinestats.Pearson(ref[0].Values, a.Values)
+			// Standardize the value so sort ASC will have strongest correlation first
+			switch {
+			case math.IsNaN(value):
+				// special case of at least one series containing all zeros which leads to div-by-zero in Pearson
+				continue
+			case direction == "abs":
+				value = math.Abs(value) * -1
+			case direction == "pos" && value >= 0:
+				value = value * -1
+			case direction == "neg" && value <= 0:
+			default:
+				continue
+			}
+			heap.Push(&mh, metricHeapElement{idx: index, val: value})
+		}
+
+		results := make([]*metricData, n)
+		for len(mh) > 0 {
+			v := heap.Pop(&mh).(metricHeapElement)
+			results[len(results)-1] = compare[v.idx]
+			if len(mh) == n {
+				break
+			}
+		}
+
+		return results
+
 	case "offsetToZero": // offsetToZero(seriesList)
 		return forEachSeriesDo(e, from, until, values, func(a *metricData, r *metricData) *metricData {
 			minimum := math.Inf(1)

--- a/expr_test.go
+++ b/expr_test.go
@@ -538,6 +538,24 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "pearson",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1"},
+					&expr{target: "metric2"},
+					&expr{val: 6, etype: etConst},
+				},
+				argString: "metric1,metric2,6",
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{43, 21, 25, 42, 57, 59}, 1, now32)},
+				metricRequest{"metric2", 0, 1}: []*metricData{makeResponse("metric2", []float64{99, 65, 79, 75, 87, 81}, 1, now32)},
+			},
+			[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0.5298089018901744},
+			"pearson(metric1,metric2,6)",
+		},
+		{
+			&expr{
 				target: "scale",
 				etype:  etFunc,
 				args: []*expr{
@@ -1214,6 +1232,30 @@ func TestEvalExpression(t *testing.T) {
 			},
 			[]float64{-2, 4, 4, 5, 5, 6},
 			"metricC",
+		},
+		{
+			&expr{
+				target: "pearsonClosest",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1"},
+					&expr{target: "metric2"},
+					&expr{val: 1, etype: etConst},
+				},
+				argString: "metric1,metric2,1",
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric1", 0, 1}: []*metricData{
+					makeResponse("metricX", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+				metricRequest{"metric2", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					makeResponse("metricB", []float64{3, math.NaN(), 5, 6, 7, 8}, 1, now32),
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				},
+			},
+			[]float64{3, math.NaN(), 5, 6, 7, 8},
+			"metricB",
 		},
 		{
 			&expr{


### PR DESCRIPTION
pearson( seriesA, seriesB, windowSize )

   Calculate Pearson score between seriesA and seriesB over windowSize.

pearsonClosest( series, seriesList, n, direction="abs" )

    Return the n series in seriesList with closest Pearson score to the
    first series argument.
    An optional direction parameter may also be given:
        "abs"   - (default) Series with any Pearson score + or - [-1 .. 1].
        "pos"   - Only series with positive correlation score [0 .. 1]
        "neg"   - Only series with negative correlation score [1 .. 0]

Note:
    Pearson (and this implementation) is intolerant of missing values.
    Missing values will result in:
        pearson(): missing values in windows propagate to windows they appear in
        pearsonClosest():
            - series : missing value will result in empty result.
            - seriesList : any series with missing value will be skipped.

    Additionally there is a special case where a series (or window) containing only
    zeros leads to a division-by-zero and will manifest similarly to if
    the series contained a missing value.