### PR TITLE
holtWinters forecasting

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/JaderDias/movingmedian"
+	"github.com/datastream/holtwinters"
 	pb "github.com/dgryski/carbonzipper/carbonzipperpb"
 	"github.com/dgryski/go-onlinestats"
 	"github.com/gogo/protobuf/proto"
@@ -67,6 +68,10 @@ func (e *expr) metrics() []metricRequest {
 			for i := range r {
 				r[i].from += offs
 				r[i].until += offs
+			}
+		case "holtWintersForecast":
+			for i := range r {
+				r[i].from -= 7 * 86400 // starts -7 days from where the original starts
 			}
 		}
 		return r
@@ -2188,6 +2193,49 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 
 		return []*metricData{&p}
+
+	case "holtWintersForecast":
+		var results []*metricData
+		args, err := getSeriesArgs(e.args, from-7*86400, until, values)
+		if err != nil {
+			return nil
+		}
+
+		const alpha = 0.1
+		const beta = 0.0035
+		const gamma = 0.1
+
+		for _, arg := range args {
+			stepTime := arg.GetStepTime()
+			numStepsToWalkToGetOriginalData := (int)((until - from) / stepTime)
+
+			//originalSeries := arg.Values[len(arg.Values)-numStepsToWalkToGetOriginalData:]
+			bootStrapSeries := arg.Values[:len(arg.Values)-numStepsToWalkToGetOriginalData]
+
+			//In line with graphite, we define a season as a single day.
+			//A period is the number of steps that make a season.
+			period := (int)((24 * 60 * 60) / stepTime)
+
+			predictions, err := holtwinters.Forecast(bootStrapSeries, alpha, beta, gamma, period, numStepsToWalkToGetOriginalData)
+			if err != nil {
+				return nil
+			}
+
+			predictionsOfInterest := predictions[len(predictions)-numStepsToWalkToGetOriginalData:]
+
+			r := metricData{FetchResponse: pb.FetchResponse{
+				Name:      proto.String(fmt.Sprintf("holtWintersForecast(%s)", arg.GetName())),
+				Values:    make([]float64, len(predictionsOfInterest)),
+				IsAbsent:  make([]bool, len(predictionsOfInterest)),
+				StepTime:  proto.Int32(arg.GetStepTime()),
+				StartTime: proto.Int32(arg.GetStartTime() + 7*86400),
+				StopTime:  proto.Int32(arg.GetStopTime()),
+			}}
+			r.Values = predictionsOfInterest
+
+			results = append(results, &r)
+		}
+		return results
 	}
 
 	log.Printf("unknown function in evalExpr:  %q\n", e.target)


### PR DESCRIPTION
Add support for holtWinters forecasting. Behaviour is improvement on
graphite behavior, so we are breaking compatibility. #66 

Bootstrap + original data is retrieved in a single request with a single
consistent stepTime, unlike what graphite does, which is to retrieve two
datasets, and then it linearly amplifies (i.e., multiplies) the
bootstrap by a factor to match the granularity of the original
dataset. It ignores the aggregation function that might have been
applied to do the rollup, in carbonapi we respect it.