### PR TITLE
Pearson closest bug

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -1867,13 +1867,13 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			heap.Push(&mh, metricHeapElement{idx: index, val: value})
 		}
 
+		if n > len(mh) {
+			n = len(mh)
+		}
 		results := make([]*metricData, n)
-		for len(mh) > 0 {
+		for i := range results {
 			v := heap.Pop(&mh).(metricHeapElement)
-			results[len(results)-1] = compare[v.idx]
-			if len(mh) == n {
-				break
-			}
+			results[i] = compare[v.idx]
 		}
 
 		return results

--- a/expr_test.go
+++ b/expr_test.go
@@ -2181,6 +2181,10 @@ func TestEvalMultipleReturns(t *testing.T) {
 			t.Errorf("failed to eval %v", tt.name)
 			continue
 		}
+		if g[0] == nil {
+			t.Errorf("returned no value %v", tt.name)
+			continue
+		}
 		if g[0].GetStepTime() == 0 {
 			t.Errorf("missing step for %+v", g)
 		}

--- a/expr_test.go
+++ b/expr_test.go
@@ -2173,6 +2173,63 @@ func TestEvalMultipleReturns(t *testing.T) {
 				"metricE": []*metricData{makeResponse("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32)},
 			},
 		},
+		{
+			&expr{
+				target: "pearsonClosest",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metricC"},
+					&expr{target: "metric*"},
+					&expr{val: 2, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					makeResponse("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32),
+				},
+				metricRequest{"metricC", 0, 1}: []*metricData{
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				},
+			},
+			"pearsonClosest",
+			map[string][]*metricData{
+				"metricC": []*metricData{makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32)},
+				"metricD": []*metricData{makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "pearsonClosest",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metricC"},
+					&expr{target: "metric*"},
+					&expr{val: 3, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					makeResponse("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32),
+				},
+				metricRequest{"metricC", 0, 1}: []*metricData{
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+				},
+			},
+			"pearsonClosest",
+			map[string][]*metricData{
+				"metricB": []*metricData{makeResponse("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32)},
+				"metricC": []*metricData{makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32)},
+				"metricD": []*metricData{makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32)},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I found that pearsonClosest() doesn't actually filter closest-n as advertised.
submitted: a test and fix (as well as a tiny change to testing code to get an error rather than a panic)