### PR TITLE
Fixes and features for tukey...

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -2364,7 +2364,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 
 		n, err := getIntArg(e, 2)
-		if err != nil {
+		if err != nil || n < 1 {
 			return nil
 		}
 
@@ -2439,6 +2439,9 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			}
 		}
 
+		if len(mh) < n {
+			n = len(mh)
+		}
 		results := make([]*metricData, n)
 		// results should be ordered ascending
 		for len(mh) > 0 {

--- a/expr.go
+++ b/expr.go
@@ -2351,7 +2351,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 		return results
 
-	case "tukeyAbove": // tukeyAbove(seriesList,basis,n,interval=0)
+	case "tukeyAbove", "tukeyBelow": // tukeyAbove(seriesList,basis,n,interval=0) , tukeyBelow(seriesList,basis,n,interval=0)
 
 		arg, err := getSeriesArg(e.args[0], from, until, values)
 		if err != nil {
@@ -2405,7 +2405,9 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		iqr := points[third] - points[first]
 
 		max := points[third] + basis*iqr
-		// min := points[first] - basis*iqr
+		min := points[first] - basis*iqr
+
+		isAbove := strings.HasSuffix(e.target, "Above")
 
 		var mh metricHeap
 
@@ -2416,8 +2418,14 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 				if a.IsAbsent[i] {
 					continue
 				}
-				if m >= max {
-					outlier++
+				if isAbove {
+					if m >= max {
+						outlier++
+					}
+				} else {
+					if m <= min {
+						outlier++
+					}
 				}
 			}
 

--- a/expr.go
+++ b/expr.go
@@ -2359,7 +2359,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 
 		basis, err := getFloatArg(e, 1)
-		if err != nil {
+		if err != nil || basis <= 0 {
 			return nil
 		}
 
@@ -2378,6 +2378,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 				i32, err = getIntervalArg(e, 3, 1)
 				interval = int(i32)
 				interval /= int(arg[0].GetStepTime())
+				// TODO(nnuss): make sure the arrays are all the same 'size'
 			default:
 				err = ErrBadType
 			}
@@ -2385,6 +2386,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 				return nil
 			}
 		}
+		// TODO(nnuss): negative intervals
 
 		// gather all the valid points
 		var points []float64

--- a/expr_test.go
+++ b/expr_test.go
@@ -2282,6 +2282,57 @@ func TestEvalMultipleReturns(t *testing.T) {
 				"metricE": []*metricData{makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32)},
 			},
 		},
+		{
+			&expr{
+				target: "tukeyBelow",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric*"},
+					&expr{val: 1.5, etype: etConst},
+					&expr{val: 5, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			"tukeyBelow",
+			map[string][]*metricData{
+				"metricA": []*metricData{makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32)},
+				"metricE": []*metricData{makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "tukeyBelow",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric*"},
+					&expr{val: 3, etype: etConst},
+					&expr{val: 5, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			"tukeyBelow",
+			map[string][]*metricData{
+				"metricE": []*metricData{makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr_test.go
+++ b/expr_test.go
@@ -2230,6 +2230,58 @@ func TestEvalMultipleReturns(t *testing.T) {
 				"metricD": []*metricData{makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32)},
 			},
 		},
+		{
+			&expr{
+				target: "tukeyAbove",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric*"},
+					&expr{val: 1.5, etype: etConst},
+					&expr{val: 5, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			"tukeyAbove",
+			map[string][]*metricData{
+				"metricA": []*metricData{makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32)},
+				"metricD": []*metricData{makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20}, 1, now32)},
+				"metricE": []*metricData{makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "tukeyAbove",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric*"},
+					&expr{val: 3, etype: etConst},
+					&expr{val: 5, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			"tukeyAbove",
+			map[string][]*metricData{
+				"metricE": []*metricData{makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Addresses the following issues (including tests):
* #100 - tukeyBelow()
* #99 - tukeyAbove(): `interval` is unused and should be optional final argument

Also a couple fixes to the use of 'n'[umber] of series to return.