### PR TITLE
Compatibility: mostDeviant() arguments changed order in graphite master

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -1543,13 +1543,20 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return min
 		})
 
-	case "mostDeviant": // mostDeviant(n, seriesList)
-		n, err := getIntArg(e, 0)
+	case "mostDeviant": // mostDeviant(seriesList, n) -or- mostDeviant(n, seriesList)
+		var nArg int
+		if e.args[0].etype != etConst {
+			// mostDeviant(seriesList, n)
+			nArg = 1
+		}
+		seriesArg := nArg ^ 1 // XOR to make seriesArg the opposite argument. ( 0^1 -> 1 ; 1^1 -> 0 )
+
+		n, err := getIntArg(e, nArg)
 		if err != nil {
 			return nil
 		}
 
-		args, err := getSeriesArg(e.args[1], from, until, values)
+		args, err := getSeriesArg(e.args[seriesArg], from, until, values)
 		if err != nil {
 			return nil
 		}

--- a/expr_test.go
+++ b/expr_test.go
@@ -2419,6 +2419,30 @@ func TestEvalMultipleReturns(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "mostDeviant",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric*"},
+					&expr{val: 2, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: []*metricData{
+					makeResponse("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					makeResponse("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+					makeResponse("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricD", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					makeResponse("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32),
+				},
+			},
+			"mostDeviant",
+			map[string][]*metricData{
+				"metricB": []*metricData{makeResponse("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32)},
+				"metricE": []*metricData{makeResponse("metricE", []float64{4, 7, 7, 7, 7, 1}, 1, now32)},
+			},
+		},
+		{
+			&expr{
 				target: "pearsonClosest",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
See
* graphite-project/graphite-web/pull/279
* graphite-project/graphite-web@44524016474cbdf6d71afb9eb105dea07766d741
... which changed the order of arguments for mostDeviant() on the mainline branch.
The 0.9.x branch retains mostDeviant(n, seriesList).

Grafana expects mostDeviant(seriesList, n).

Accept it either way by detecting the type of the first argument and
changing the logic to "Where is the 'n' arg?" and seriesList is always
"the other one" ( nArg ^ 1 ).