### PR TITLE
Named arguments

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -2183,7 +2183,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		natSort, err := getBoolArgDefault(e, 1, false)
+		natSort, err := getBoolNamedOrPosArgDefault(e, "natural", 1, false)
 		if err != nil {
 			return nil
 		}

--- a/expr.go
+++ b/expr.go
@@ -325,7 +325,7 @@ func getStringArg(e *expr, n int) (string, error) {
 		return "", ErrMissingArgument
 	}
 
-	return doGetStringArgDefault(e.args[n], "")
+	return doGetStringArg(e.args[n])
 }
 
 func getStringArgDefault(e *expr, n int, s string) (string, error) {
@@ -333,28 +333,23 @@ func getStringArgDefault(e *expr, n int, s string) (string, error) {
 		return s, nil
 	}
 
-	return doGetStringArgDefault(e.args[n], s)
+	return doGetStringArg(e.args[n])
 }
 
 func getStringNamedOrPosArgDefault(e *expr, k string, n int, s string) (string, error) {
 	if a := getNamedArg(e, k); a != nil {
-		return doGetStringArgDefault(a, s)
+		return doGetStringArg(a)
 	}
 
 	return getStringArgDefault(e, n, s)
 }
 
-func doGetStringArgDefault(e *expr, s string) (string, error) {
+func doGetStringArg(e *expr) (string, error) {
 	if e.etype != etString {
 		return "", ErrBadType
 	}
 
-	v := e.valStr
-	if v == "" {
-		return s, nil
-	}
-
-	return v, nil
+	return e.valStr, nil
 }
 
 func getIntervalArg(e *expr, n int, defaultSign int) (int32, error) {
@@ -379,7 +374,7 @@ func getFloatArg(e *expr, n int) (float64, error) {
 		return 0, ErrMissingArgument
 	}
 
-	return doGetFloatArgDefault(e.args[n], 0)
+	return doGetFloatArg(e.args[n])
 }
 
 func getFloatArgDefault(e *expr, n int, v float64) (float64, error) {
@@ -387,28 +382,23 @@ func getFloatArgDefault(e *expr, n int, v float64) (float64, error) {
 		return v, nil
 	}
 
-	return doGetFloatArgDefault(e.args[n], v)
+	return doGetFloatArg(e.args[n])
 }
 
 func getFloatNamedOrPosArgDefault(e *expr, k string, n int, v float64) (float64, error) {
 	if a := getNamedArg(e, k); a != nil {
-		return doGetFloatArgDefault(a, v)
+		return doGetFloatArg(a)
 	}
 
 	return getFloatArgDefault(e, n, v)
 }
 
-func doGetFloatArgDefault(e *expr, v float64) (float64, error) {
+func doGetFloatArg(e *expr) (float64, error) {
 	if e.etype != etConst {
 		return 0, ErrBadType
 	}
 
-	f := e.val
-	if f == 0 {
-		return v, nil
-	}
-
-	return f, nil
+	return e.val, nil
 }
 
 func getIntArg(e *expr, n int) (int, error) {
@@ -416,7 +406,7 @@ func getIntArg(e *expr, n int) (int, error) {
 		return 0, ErrMissingArgument
 	}
 
-	return doGetIntArgDefault(e.args[n], 0)
+	return doGetIntArg(e.args[n])
 }
 
 func getIntArgs(e *expr, n int) ([]int, error) {
@@ -443,33 +433,28 @@ func getIntArgDefault(e *expr, n int, d int) (int, error) {
 		return d, nil
 	}
 
-	return doGetIntArgDefault(e.args[n], d)
+	return doGetIntArg(e.args[n])
 }
 
 func getIntNamedOrPosArgDefault(e *expr, k string, n int, d int) (int, error) {
 	if a := getNamedArg(e, k); a != nil {
-		return doGetIntArgDefault(a, d)
+		return doGetIntArg(a)
 	}
 
 	return getIntArgDefault(e, n, d)
 }
 
-func doGetIntArgDefault(e *expr, d int) (int, error) {
+func doGetIntArg(e *expr) (int, error) {
 	if e.etype != etConst {
 		return 0, ErrBadType
 	}
 
-	v := int(e.val)
-	if v == 0 {
-		return d, nil
-	}
-
-	return v, nil
+	return int(e.val), nil
 }
 
 func getBoolNamedOrPosArgDefault(e *expr, k string, n int, b bool) (bool, error) {
 	if a := getNamedArg(e, k); a != nil {
-		return doGetBoolArgDefault(a, b)
+		return doGetBoolArg(a)
 	}
 
 	return getBoolArgDefault(e, n, b)
@@ -479,10 +464,11 @@ func getBoolArgDefault(e *expr, n int, b bool) (bool, error) {
 	if len(e.args) <= n {
 		return b, nil
 	}
-	return doGetBoolArgDefault(e.args[n], b)
+
+	return doGetBoolArg(e.args[n])
 }
 
-func doGetBoolArgDefault(e *expr, b bool) (bool, error) {
+func doGetBoolArg(e *expr) (bool, error) {
 	if e.etype != etName {
 		return false, ErrBadType
 	}

--- a/expr.go
+++ b/expr.go
@@ -1333,7 +1333,12 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			case 2:
 				name = fmt.Sprintf("hitcount(%s,'%s')", arg.GetName(), e.args[1].valStr)
 			case 3:
-				name = fmt.Sprintf("hitcount(%s,'%s',%s)", arg.GetName(), e.args[1].valStr, e.args[2].target)
+				name = fmt.Sprintf(
+					"hitcount(%s,'%s',%v)",
+					arg.GetName(),
+					e.args[1].valStr,
+					alignToInterval,
+				)
 			}
 
 			r := metricData{FetchResponse: pb.FetchResponse{
@@ -2430,9 +2435,20 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			case 2:
 				name = fmt.Sprintf("summarize(%s,'%s')", arg.GetName(), e.args[1].valStr)
 			case 3:
-				name = fmt.Sprintf("summarize(%s,'%s','%s')", arg.GetName(), e.args[1].valStr, e.args[2].valStr)
+				name = fmt.Sprintf(
+					"summarize(%s,'%s','%s')",
+					arg.GetName(),
+					e.args[1].valStr,
+					summarizeFunction,
+				)
 			case 4:
-				name = fmt.Sprintf("summarize(%s,'%s','%s',%s)", arg.GetName(), e.args[1].valStr, e.args[2].valStr, e.args[3].target)
+				name = fmt.Sprintf(
+					"summarize(%s,'%s','%s',%v)",
+					arg.GetName(),
+					e.args[1].valStr,
+					summarizeFunction,
+					alignToFrom,
+				)
 			}
 
 			r := metricData{FetchResponse: pb.FetchResponse{

--- a/expr.go
+++ b/expr.go
@@ -343,7 +343,7 @@ func getStringNamedOrPosArgDefault(e *expr, k string, n int, s string) (string, 
 }
 
 func doGetStringArgDefault(e *expr, s string) (string, error) {
-	if e.etype != etString {
+	if e.etype != etString && e.etype != etKV {
 		return "", ErrBadType
 	}
 
@@ -377,11 +377,7 @@ func getFloatArg(e *expr, n int) (float64, error) {
 		return 0, ErrMissingArgument
 	}
 
-	if e.args[n].etype != etConst {
-		return 0, ErrBadType
-	}
-
-	return e.args[n].val, nil
+	return doGetFloatArgDefault(e.args[n], 0)
 }
 
 func getFloatArgDefault(e *expr, n int, v float64) (float64, error) {
@@ -389,11 +385,32 @@ func getFloatArgDefault(e *expr, n int, v float64) (float64, error) {
 		return v, nil
 	}
 
-	if e.args[n].etype != etConst {
+	return doGetFloatArgDefault(e.args[n], v)
+}
+
+func getFloatNamedOrPosArgDefault(e *expr, k string, n int, v float64) (float64, error) {
+	if len(e.args) <= n {
+		return v, nil
+	}
+
+	if a := getNamedArg(e.args, k); a != nil {
+		return doGetFloatArgDefault(a, v)
+	}
+
+	return getFloatArgDefault(e, n, v)
+}
+
+func doGetFloatArgDefault(e *expr, v float64) (float64, error) {
+	if e.etype != etConst && e.etype != etKV {
 		return 0, ErrBadType
 	}
 
-	return e.args[n].val, nil
+	f := e.val
+	if f == 0 {
+		return v, nil
+	}
+
+	return f, nil
 }
 
 func getIntArg(e *expr, n int) (int, error) {
@@ -401,11 +418,7 @@ func getIntArg(e *expr, n int) (int, error) {
 		return 0, ErrMissingArgument
 	}
 
-	if e.args[n].etype != etConst {
-		return 0, ErrBadType
-	}
-
-	return int(e.args[n].val), nil
+	return doGetIntArgDefault(e.args[n], 0)
 }
 
 func getIntArgs(e *expr, n int) ([]int, error) {
@@ -432,11 +445,32 @@ func getIntArgDefault(e *expr, n int, d int) (int, error) {
 		return d, nil
 	}
 
-	if e.args[n].etype != etConst {
+	return doGetIntArgDefault(e.args[n], d)
+}
+
+func getIntNamedOrPasArgDefault(e *expr, k string, n int, d int) (int, error) {
+	if len(e.args) <= n {
+		return d, nil
+	}
+
+	if a := getNamedArg(e.args, k); a != nil {
+		return doGetIntArgDefault(a, d)
+	}
+
+	return getIntArgDefault(e, n, d)
+}
+
+func doGetIntArgDefault(e *expr, d int) (int, error) {
+	if e.etype != etConst && e.etype != etKV {
 		return 0, ErrBadType
 	}
 
-	return int(e.args[n].val), nil
+	v := int(e.val)
+	if v == 0 {
+		return d, nil
+	}
+
+	return v, nil
 }
 
 func getBoolNamedOrPosArgDefault(e *expr, k string, n int, b bool) (bool, error) {
@@ -459,7 +493,7 @@ func getBoolArgDefault(e *expr, n int, b bool) (bool, error) {
 }
 
 func doGetBoolArgDefault(e *expr, b bool) (bool, error) {
-	if e.etype != etName {
+	if e.etype != etName && e.etype != etKV {
 		return false, ErrBadType
 	}
 

--- a/expr.go
+++ b/expr.go
@@ -1313,7 +1313,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		alignToInterval, err := getBoolArgDefault(e, 2, false)
+		alignToInterval, err := getBoolNamedOrPosArgDefault(e, "alignToInterval", 2, false)
 		if err != nil {
 			return nil
 		}
@@ -1427,10 +1427,12 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		if err != nil {
 			return nil
 		}
-		keep, err := getIntArgDefault(e, 1, -1)
+
+		keep, err := getIntNamedOrPasArgDefault(e, "limit", 1, -1)
 		if err != nil {
 			return nil
 		}
+
 		var results []*metricData
 
 		for _, a := range arg {
@@ -1579,7 +1581,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		if err != nil {
 			return nil
 		}
-		base, err := getIntArgDefault(e, 1, 10)
+		base, err := getIntNamedOrPasArgDefault(e, "base", 1, 10)
 		if err != nil {
 			return nil
 		}
@@ -1813,7 +1815,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		maxValue, err := getFloatArgDefault(e, 1, math.NaN())
+		maxValue, err := getFloatNamedOrPosArgDefault(e, "maxValue", 1, math.NaN())
 		if err != nil {
 			return nil
 		}
@@ -2004,7 +2006,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		direction, err := getStringArgDefault(e, 3, "abs")
+		direction, err := getStringNamedOrPosArgDefault(e, "direction", 3, "abs")
 		if err != nil && len(e.args) > 3 {
 			return nil
 		}
@@ -2382,7 +2384,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		interpolate, err := getBoolArgDefault(e, 2, false)
+		interpolate, err := getBoolNamedOrPosArgDefault(e, "interpolate", 2, false)
 		if err != nil {
 			return nil
 		}
@@ -2403,12 +2405,12 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		summarizeFunction, err := getStringArgDefault(e, 2, "sum")
+		summarizeFunction, err := getStringNamedOrPosArgDefault(e, "func", 2, "sum")
 		if err != nil {
 			return nil
 		}
 
-		alignToFrom, err := getBoolArgDefault(e, 3, false)
+		alignToFrom, err := getBoolNamedOrPosArgDefault(e, "alignToFrom", 3, false)
 		if err != nil {
 			return nil
 		}
@@ -2554,7 +2556,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		if err != nil {
 			return nil
 		}
-		defv, err := getFloatArgDefault(e, 1, 0)
+		defv, err := getFloatNamedOrPosArgDefault(e, "default", 1, 0)
 		if err != nil {
 			return nil
 		}
@@ -2723,9 +2725,9 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		stackName, err := getStringArg(e, 1) // get stackName
+		stackName, err := getStringNamedOrPosArgDefault(e, "stackname", 1, "__DEFAULT__")
 		if err != nil {
-			stackName = "__DEFAULT__"
+			return nil
 		}
 
 		var results []*metricData
@@ -2842,27 +2844,23 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 
 		return []*metricData{&p}
 
-	case "threshold":
+	case "threshold": // threshold(value, label=None, color=None)
+		// XXX does not match graphite's signature
+
 		value, err := getFloatArg(e, 0)
 
 		if err != nil {
 			return nil
 		}
 
-		name := fmt.Sprintf("%g", value)
-		if len(e.args) > 1 {
-			name, err = getStringArg(e, 1)
-			if err != nil {
-				return nil
-			}
+		name, err := getStringNamedOrPosArgDefault(e, "label", 1, fmt.Sprintf("%g", value))
+		if err != nil {
+			return nil
 		}
 
-		var color string
-		if len(e.args) > 2 {
-			color, err = getStringArg(e, 2)
-			if err != nil {
-				return nil
-			}
+		color, err := getStringNamedOrPosArgDefault(e, "color", 2, "")
+		if err != nil {
+			return nil
 		}
 
 		p := metricData{

--- a/expr.go
+++ b/expr.go
@@ -331,10 +331,6 @@ func getStringArgDefault(e *expr, n int, s string) (string, error) {
 }
 
 func getStringNamedOrPosArgDefault(e *expr, k string, n int, s string) (string, error) {
-	if len(e.args) <= n {
-		return s, nil
-	}
-
 	if a := getNamedArg(e.args, k); a != nil {
 		return doGetStringArgDefault(a, s)
 	}
@@ -389,10 +385,6 @@ func getFloatArgDefault(e *expr, n int, v float64) (float64, error) {
 }
 
 func getFloatNamedOrPosArgDefault(e *expr, k string, n int, v float64) (float64, error) {
-	if len(e.args) <= n {
-		return v, nil
-	}
-
 	if a := getNamedArg(e.args, k); a != nil {
 		return doGetFloatArgDefault(a, v)
 	}
@@ -449,10 +441,6 @@ func getIntArgDefault(e *expr, n int, d int) (int, error) {
 }
 
 func getIntNamedOrPosArgDefault(e *expr, k string, n int, d int) (int, error) {
-	if len(e.args) <= n {
-		return d, nil
-	}
-
 	if a := getNamedArg(e.args, k); a != nil {
 		return doGetIntArgDefault(a, d)
 	}
@@ -474,10 +462,6 @@ func doGetIntArgDefault(e *expr, d int) (int, error) {
 }
 
 func getBoolNamedOrPosArgDefault(e *expr, k string, n int, b bool) (bool, error) {
-	if len(e.args) <= n {
-		return b, nil
-	}
-
 	if a := getNamedArg(e.args, k); a != nil {
 		return doGetBoolArgDefault(a, b)
 	}

--- a/expr.go
+++ b/expr.go
@@ -319,11 +319,7 @@ func getStringArg(e *expr, n int) (string, error) {
 		return "", ErrMissingArgument
 	}
 
-	if e.args[n].etype != etString {
-		return "", ErrBadType
-	}
-
-	return e.args[n].valStr, nil
+	return doGetStringArgDefault(e.args[n], "")
 }
 
 func getStringArgDefault(e *expr, n int, s string) (string, error) {
@@ -331,11 +327,32 @@ func getStringArgDefault(e *expr, n int, s string) (string, error) {
 		return s, nil
 	}
 
-	if e.args[n].etype != etString {
+	return doGetStringArgDefault(e.args[n], s)
+}
+
+func getStringNamedOrPosArgDefault(e *expr, k string, n int, s string) (string, error) {
+	if len(e.args) <= n {
+		return s, nil
+	}
+
+	if a := getNamedArg(e.args, k); a != nil {
+		return doGetStringArgDefault(a, s)
+	}
+
+	return getStringArgDefault(e, n, s)
+}
+
+func doGetStringArgDefault(e *expr, s string) (string, error) {
+	if e.etype != etString {
 		return "", ErrBadType
 	}
 
-	return e.args[n].valStr, nil
+	v := e.valStr
+	if v == "" {
+		return s, nil
+	}
+
+	return v, nil
 }
 
 func getIntervalArg(e *expr, n int, defaultSign int) (int32, error) {

--- a/expr.go
+++ b/expr.go
@@ -448,7 +448,7 @@ func getIntArgDefault(e *expr, n int, d int) (int, error) {
 	return doGetIntArgDefault(e.args[n], d)
 }
 
-func getIntNamedOrPasArgDefault(e *expr, k string, n int, d int) (int, error) {
+func getIntNamedOrPosArgDefault(e *expr, k string, n int, d int) (int, error) {
 	if len(e.args) <= n {
 		return d, nil
 	}
@@ -1433,7 +1433,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil
 		}
 
-		keep, err := getIntNamedOrPasArgDefault(e, "limit", 1, -1)
+		keep, err := getIntNamedOrPosArgDefault(e, "limit", 1, -1)
 		if err != nil {
 			return nil
 		}
@@ -1586,7 +1586,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		if err != nil {
 			return nil
 		}
-		base, err := getIntNamedOrPasArgDefault(e, "base", 1, 10)
+		base, err := getIntNamedOrPosArgDefault(e, "base", 1, 10)
 		if err != nil {
 			return nil
 		}

--- a/expr_test.go
+++ b/expr_test.go
@@ -498,9 +498,9 @@ func TestEvalExpression(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1.foo.*.*"},
 					&expr{val: 50, etype: etConst},
-					&expr{target: "true", etype: etName},
+					&expr{key: "interpolate", target: "true", etype: etKV},
 				},
-				argString: "metric1.foo.*.*,50,true",
+				argString: "metric1.foo.*.*,50,interpolate=true",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1.foo.*.*", 0, 1}: []*metricData{
@@ -510,7 +510,7 @@ func TestEvalExpression(t *testing.T) {
 					makeResponse("metric1.foo.bar2.qux", []float64{7, 8, 9, 10, 11, math.NaN()}, 1, now32),
 				},
 			},
-			[]*metricData{makeResponse("percentileOfSeries(metric1.foo.*.*,50,true)", []float64{6.5, 7.5, 8.5, 9.5, 11, math.NaN()}, 1, now32)},
+			[]*metricData{makeResponse("percentileOfSeries(metric1.foo.*.*,50,interpolate=true)", []float64{6.5, 7.5, 8.5, 9.5, 11, math.NaN()}, 1, now32)},
 		},
 		{
 			&expr{
@@ -559,9 +559,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{val: 32, etype: etConst},
+					&expr{key: "maxValue", val: 32, etype: etKV},
 				},
-				argString: "metric1,32",
+				argString: "metric1,maxValue=32",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{2, 4, 0, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
@@ -740,9 +740,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{val: 3, etype: etConst},
+					&expr{key: "limit", val: 3, etype: etKV},
 				},
-				argString: "metric1,3",
+				argString: "metric1,limit=3",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
@@ -1115,9 +1115,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{val: 5, etype: etConst},
+					&expr{key: "default", val: 5, etype: etKV},
 				},
-				argString: "metric1,5",
+				argString: "metric1,default=5",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
@@ -1301,9 +1301,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{val: 2, etype: etConst},
+					&expr{key: "base", val: 2, etype: etKV},
 				},
-				argString: "metric1,2",
+				argString: "metric1,base=2",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, 2, 4, 8, 16, 32}, 1, now32)},
@@ -1471,8 +1471,9 @@ func TestEvalExpression(t *testing.T) {
 					&expr{target: "metric1"},
 					&expr{target: "metric2"},
 					&expr{val: 1, etype: etConst},
+					&expr{key: "direction", valStr: "abs", etype: etKV},
 				},
-				argString: "metric1,metric2,1",
+				argString: "metric1,metric2,1,direction='abs'",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{
@@ -1684,9 +1685,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{target: "true", etype: etName},
+					&expr{key: "natural", target: "true", etype: etKV},
 				},
-				argString: "metric1,true",
+				argString: "metric1,natural=true",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{
@@ -1741,9 +1742,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{val: 42.42, etype: etConst},
-					&expr{valStr: "fourty-two", etype: etString},
+					&expr{key: "label", valStr: "fourty-two", etype: etKV},
 				},
-				argString: "42.42",
+				argString: "42.42,labe='fourty-two'",
 			},
 			map[metricRequest][]*metricData{},
 			[]*metricData{makeResponse("fourty-two",
@@ -1755,11 +1756,11 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{val: 42.42, etype: etConst},
-					&expr{valStr: "fourty-two-blue", etype: etString},
-					&expr{valStr: "blue", etype: etString},
+					&expr{key: "label", valStr: "fourty-two-blue", etype: etKV},
+					&expr{key: "color", valStr: "blue", etype: etKV},
 					//TODO(nnuss): test blue is being set rather than just not causing expression to parse/fail
 				},
-				argString: "42.42",
+				argString: "42.42,label='fourty-two-blue',color='blue'",
 			},
 			map[metricRequest][]*metricData{},
 			[]*metricData{makeResponse("fourty-two-blue",
@@ -2017,9 +2018,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{valStr: "avg", etype: etString},
+					&expr{key: "func", valStr: "avg", etype: etString},
 				},
-				argString: "metric1,'5s','avg'",
+				argString: "metric1,'5s',func='avg'",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
@@ -2037,9 +2038,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{valStr: "max", etype: etString},
+					&expr{key: "func", valStr: "max", etype: etKV},
 				},
-				argString: "metric1,'5s','max'",
+				argString: "metric1,'5s',func='max'",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
@@ -2057,9 +2058,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{valStr: "min", etype: etString},
+					&expr{key: "func", valStr: "min", etype: etKV},
 				},
-				argString: "metric1,'5s','min'",
+				argString: "metric1,'5s',func='min'",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
@@ -2077,9 +2078,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{valStr: "last", etype: etString},
+					&expr{key: "func", valStr: "last", etype: etKV},
 				},
-				argString: "metric1,'5s','last'",
+				argString: "metric1,'5s',func='last'",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{1, 0, 0, 0.5, 1, 2, 1, 1, 1.5, 2, 3, 2, 2, 1.5, 3, 4, 3, 2, 3, 4.5, 5, 5, 5, 5, 5}, 1, now32)},
@@ -2219,10 +2220,10 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "10min", etype: etString},
-					&expr{valStr: "sum", etype: etString},
-					&expr{target: "true", etype: etName},
+					&expr{key: "func", valStr: "sum", etype: etKV},
+					&expr{key: "alignToFrom", target: "true", etype: etKV},
 				},
-				argString: "metric1,'10min','sum',true",
+				argString: "metric1,'10min',func='sum',alignToFrom=true",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{
@@ -2290,9 +2291,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "1h", etype: etString},
-					&expr{target: "true", etype: etName},
+					&expr{key: "alignToInterval", target: "true", etype: etKV},
 				},
-				argString: "metric1,'1h'",
+				argString: "metric1,'1h',alignToInterval=true",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{

--- a/expr_test.go
+++ b/expr_test.go
@@ -258,11 +258,9 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype:  etKV,
-						valStr: "value",
-						key:    "key",
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etString, valStr: "value"},
 				},
 				argString: "metric, key='value'",
 			},
@@ -274,11 +272,9 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype:  etKV,
-						key:    "key",
-						target: "true",
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etName, target: "true"},
 				},
 				argString: "metric, key=true",
 			},
@@ -290,11 +286,9 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype: etKV,
-						key:   "key",
-						val:   1,
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etConst, val: 1},
 				},
 				argString: "metric, key=1",
 			},
@@ -306,11 +300,9 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype: etKV,
-						key:   "key",
-						val:   0.1,
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etConst, val: 0.1},
 				},
 				argString: "metric, key=0.1",
 			},
@@ -324,11 +316,9 @@ func TestParseExpr(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric"},
 					&expr{etype: etConst, val: 1},
-					&expr{
-						etype:  etKV,
-						key:    "key",
-						valStr: "value",
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etString, valStr: "value"},
 				},
 				argString: "metric, 1, key='value'",
 			},
@@ -340,12 +330,10 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype:  etKV,
-						key:    "key",
-						valStr: "value",
-					},
 					&expr{etype: etConst, val: 1},
+				},
+				namedArgs: map[string]*expr{
+					"key": &expr{etype: etString, valStr: "value"},
 				},
 				argString: "metric, key='value', 1",
 			},
@@ -357,16 +345,10 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype:  etKV,
-						key:    "key1",
-						valStr: "value1",
-					},
-					&expr{
-						etype:  etKV,
-						key:    "key2",
-						valStr: "value2",
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key1": &expr{etype: etString, valStr: "value1"},
+					"key2": &expr{etype: etString, valStr: "value2"},
 				},
 				argString: "metric, key1='value1', key2='value2'",
 			},
@@ -378,16 +360,10 @@ func TestParseExpr(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric"},
-					&expr{
-						etype:  etKV,
-						key:    "key2",
-						valStr: "value2",
-					},
-					&expr{
-						etype:  etKV,
-						key:    "key1",
-						valStr: "value1",
-					},
+				},
+				namedArgs: map[string]*expr{
+					"key2": &expr{etype: etString, valStr: "value2"},
+					"key1": &expr{etype: etString, valStr: "value1"},
 				},
 				argString: "metric, key2='value2', key1='value1'",
 			},
@@ -519,7 +495,9 @@ func TestEvalExpression(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1.foo.*.*"},
 					&expr{val: 50, etype: etConst},
-					&expr{key: "interpolate", target: "true", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"interpolate": &expr{target: "true", etype: etName},
 				},
 				argString: "metric1.foo.*.*,50,interpolate=true",
 			},
@@ -580,7 +558,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{key: "maxValue", val: 32, etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"maxValue": &expr{val: 32, etype: etConst},
 				},
 				argString: "metric1,maxValue=32",
 			},
@@ -761,7 +741,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{key: "limit", val: 3, etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"limit": &expr{val: 3, etype: etConst},
 				},
 				argString: "metric1,limit=3",
 			},
@@ -1136,7 +1118,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{key: "default", val: 5, etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"default": &expr{val: 5, etype: etConst},
 				},
 				argString: "metric1,default=5",
 			},
@@ -1322,7 +1306,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{key: "base", val: 2, etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"base": &expr{val: 2, etype: etConst},
 				},
 				argString: "metric1,base=2",
 			},
@@ -1492,7 +1478,9 @@ func TestEvalExpression(t *testing.T) {
 					&expr{target: "metric1"},
 					&expr{target: "metric2"},
 					&expr{val: 1, etype: etConst},
-					&expr{key: "direction", valStr: "abs", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"direction": &expr{valStr: "abs", etype: etString},
 				},
 				argString: "metric1,metric2,1,direction='abs'",
 			},
@@ -1706,7 +1694,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{target: "metric1"},
-					&expr{key: "natural", target: "true", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"natural": &expr{target: "true", etype: etName},
 				},
 				argString: "metric1,natural=true",
 			},
@@ -1763,9 +1753,9 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{val: 42.42, etype: etConst},
-					&expr{key: "label", valStr: "fourty-two", etype: etKV},
+					&expr{valStr: "fourty-two", etype: etString},
 				},
-				argString: "42.42,labe='fourty-two'",
+				argString: "42.42,'fourty-two'",
 			},
 			map[metricRequest][]*metricData{},
 			[]*metricData{makeResponse("fourty-two",
@@ -1777,8 +1767,58 @@ func TestEvalExpression(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					&expr{val: 42.42, etype: etConst},
-					&expr{key: "label", valStr: "fourty-two-blue", etype: etKV},
-					&expr{key: "color", valStr: "blue", etype: etKV},
+					&expr{valStr: "fourty-two", etype: etString},
+					&expr{valStr: "blue", etype: etString},
+				},
+				argString: "42.42,'fourty-two','blue'",
+			},
+			map[metricRequest][]*metricData{},
+			[]*metricData{makeResponse("fourty-two",
+				[]float64{42.42, 42.42}, 1, now32)},
+		},
+		{
+			&expr{
+				target: "threshold",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{val: 42.42, etype: etConst},
+				},
+				namedArgs: map[string]*expr{
+					"label": &expr{valStr: "fourty-two", etype: etString},
+				},
+				argString: "42.42,label='fourty-two'",
+			},
+			map[metricRequest][]*metricData{},
+			[]*metricData{makeResponse("fourty-two",
+				[]float64{42.42, 42.42}, 1, now32)},
+		},
+		{
+			&expr{
+				target: "threshold",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{val: 42.42, etype: etConst},
+				},
+				namedArgs: map[string]*expr{
+					"color": &expr{valStr: "blue", etype: etString},
+					//TODO(nnuss): test blue is being set rather than just not causing expression to parse/fail
+				},
+				argString: "42.42,color='blue'",
+			},
+			map[metricRequest][]*metricData{},
+			[]*metricData{makeResponse("42.42",
+				[]float64{42.42, 42.42}, 1, now32)},
+		},
+		{
+			&expr{
+				target: "threshold",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{val: 42.42, etype: etConst},
+				},
+				namedArgs: map[string]*expr{
+					"label": &expr{valStr: "fourty-two-blue", etype: etString},
+					"color": &expr{valStr: "blue", etype: etString},
 					//TODO(nnuss): test blue is being set rather than just not causing expression to parse/fail
 				},
 				argString: "42.42,label='fourty-two-blue',color='blue'",
@@ -2039,7 +2079,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{key: "func", valStr: "avg", etype: etString},
+				},
+				namedArgs: map[string]*expr{
+					"func": &expr{valStr: "avg", etype: etString},
 				},
 				argString: "metric1,'5s',func='avg'",
 			},
@@ -2059,7 +2101,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{key: "func", valStr: "max", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"func": &expr{valStr: "max", etype: etString},
 				},
 				argString: "metric1,'5s',func='max'",
 			},
@@ -2079,7 +2123,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{key: "func", valStr: "min", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"func": &expr{valStr: "min", etype: etString},
 				},
 				argString: "metric1,'5s',func='min'",
 			},
@@ -2099,7 +2145,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "5s", etype: etString},
-					&expr{key: "func", valStr: "last", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"func": &expr{valStr: "last", etype: etString},
 				},
 				argString: "metric1,'5s',func='last'",
 			},
@@ -2241,10 +2289,37 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "10min", etype: etString},
-					&expr{key: "alignToFrom", target: "true", etype: etKV},
-					&expr{key: "func", valStr: "sum", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"alignToFrom": &expr{target: "true", etype: etName},
+					"func":        &expr{valStr: "sum", etype: etString},
 				},
 				argString: "metric1,'10min',alignToFrom=true,func='sum'",
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{
+					1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
+					3, 3, 3, 3, 3, 4, 4, 4, 4, 4,
+					5, 5, 5, 5, 5}, 60, tenThirtyTwo)},
+			},
+			[]float64{15, 35, 25},
+			"summarize(metric1,'10min','sum',true)",
+			600,
+			tenThirtyTwo,
+			tenThirtyTwo + 25*60,
+		},
+		{
+			&expr{
+				target: "summarize",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1"},
+					&expr{valStr: "10min", etype: etString},
+				},
+				namedArgs: map[string]*expr{
+					"alignToFrom": &expr{target: "true", etype: etName},
+				},
+				argString: "metric1,'10min',alignToFrom=true",
 			},
 			map[metricRequest][]*metricData{
 				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{
@@ -2335,7 +2410,9 @@ func TestEvalSummarize(t *testing.T) {
 				args: []*expr{
 					&expr{target: "metric1"},
 					&expr{valStr: "1h", etype: etString},
-					&expr{key: "alignToInterval", target: "true", etype: etKV},
+				},
+				namedArgs: map[string]*expr{
+					"alignToInterval": &expr{target: "true", etype: etName},
 				},
 				argString: "metric1,'1h',alignToInterval=true",
 			},

--- a/expr_test.go
+++ b/expr_test.go
@@ -250,6 +250,128 @@ func TestParseExpr(t *testing.T) {
 				argString: "metric1, -3",
 			},
 		},
+
+		{
+			"func(metric, key='value')",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype:  etKV,
+						valStr: "value",
+						key:    "key",
+					},
+				},
+				argString: "metric, key='value'",
+			},
+		},
+		{
+			"func(metric, key=true)",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype:  etKV,
+						key:    "key",
+						target: "true",
+					},
+				},
+				argString: "metric, key=true",
+			},
+		},
+		{
+			"func(metric, key=1)",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype: etKV,
+						key:   "key",
+						val:   1,
+					},
+				},
+				argString: "metric, key=1",
+			},
+		},
+		{
+			"func(metric, key=0.1)",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype: etKV,
+						key:   "key",
+						val:   0.1,
+					},
+				},
+				argString: "metric, key=0.1",
+			},
+		},
+
+		{
+			"func(metric, 1, key='value')",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{etype: etConst, val: 1},
+					&expr{
+						etype:  etKV,
+						key:    "key",
+						valStr: "value",
+					},
+				},
+				argString: "metric, 1, key='value'",
+			},
+		},
+		{
+			"func(metric, key='value', 1)",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype:  etKV,
+						key:    "key",
+						valStr: "value",
+					},
+					&expr{etype: etConst, val: 1},
+				},
+				argString: "metric, key='value', 1",
+			},
+		},
+		{
+			"func(metric, key1='value1', key2='value2')",
+			&expr{
+				target: "func",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric"},
+					&expr{
+						etype:  etKV,
+						key:    "key1",
+						valStr: "value1",
+					},
+					&expr{
+						etype:  etKV,
+						key:    "key2",
+						valStr: "value2",
+					},
+				},
+				argString: "metric, key1='value1', key2='value2'",
+			},
+		},
+
 		{
 			`foo.{bar,baz}.qux`,
 			&expr{


### PR DESCRIPTION
This adds the ability to parse expressions with named arguments, e.g. `summarize(foo.*, '1min', func='max')`. To work with named arguments it adds a bunch of `getTypeNamedOrPosArgDefault()` functions to be used in place of `getTypeArgDefault()` when named arguments support is needed.
Also, I added named arguments to functions that have them according to graphite's documentation.