### PR TITLE
propagate eval errors to users

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -1973,9 +1973,9 @@ func TestEvalExpression(t *testing.T) {
 			oldValues[key] = entry
 		}
 
-		g := evalExpr(tt.e, 0, 1, tt.m)
-		if g == nil {
-			t.Errorf("failed to eval %s", tt.e.target)
+		g, err := evalExpr(tt.e, 0, 1, tt.m)
+		if err != nil {
+			t.Errorf("failed to eval %s: %s", tt.e.target, err)
 			continue
 		}
 		if len(g) != len(tt.want) {
@@ -2431,9 +2431,9 @@ func TestEvalSummarize(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		g := evalExpr(tt.e, 0, 1, tt.m)
-		if g == nil {
-			t.Errorf("failed to eval %v", tt.name)
+		g, err := evalExpr(tt.e, 0, 1, tt.m)
+		if err != nil {
+			t.Errorf("failed to eval %v: %s", tt.name, err)
 			continue
 		}
 		if g[0].GetStepTime() != tt.step {
@@ -2876,9 +2876,9 @@ func TestEvalMultipleReturns(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		g := evalExpr(tt.e, 0, 1, tt.m)
-		if g == nil {
-			t.Errorf("failed to eval %v", tt.name)
+		g, err := evalExpr(tt.e, 0, 1, tt.m)
+		if err != nil {
+			t.Errorf("failed to eval %v: %s", tt.name, err)
 			continue
 		}
 		if g[0] == nil {
@@ -3008,9 +3008,9 @@ func TestEvalCustomFromUntil(t *testing.T) {
 			oldValues[key] = entry
 		}
 
-		g := evalExpr(tt.e, tt.from, tt.until, tt.m)
-		if g == nil {
-			t.Errorf("failed to eval %v", tt.name)
+		g, err := evalExpr(tt.e, tt.from, tt.until, tt.m)
+		if err != nil {
+			t.Errorf("failed to eval %v: %s", tt.name, err)
 			continue
 		}
 		if g[0] == nil {


### PR DESCRIPTION
before the patch:

```
$ http_proxy= curl -v 'http://127.0.0.1:8082/render?format=json&target=foobar(foo)'
* About to connect() to 127.0.0.1 port 8082 (#0)
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8082 (#0)
> GET /render?format=json&target=foobar(foo) HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 127.0.0.1:8082
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Access-Control-Allow-Methods: POST, GET, OPTIONS
< Access-Control-Allow-Origin: *
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 02 Mar 2016 16:17:40 GMT
< Content-Length: 35
<
Internal Server Error: eval failed
* Connection #0 to host 127.0.0.1 left intact
```

after the patch:

```
$ http_proxy= curl -v 'http://127.0.0.1:8082/render?format=json&target=foo(bar)&target=tukeyAbove(1,2,3)&target=pearsonClosest(foo,bar,baz,quux)'
* About to connect() to 127.0.0.1 port 8082 (#0)
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8082 (#0)
> GET /render?format=json&target=foo(bar)&target=tukeyAbove(1,2,3)&target=pearsonClosest(foo,bar,baz,quux) HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 127.0.0.1:8082
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Access-Control-Allow-Methods: POST, GET, OPTIONS
< Access-Control-Allow-Origin: *
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Thu, 24 Mar 2016 14:43:58 GMT
< Content-Length: 172
<
Encountered the following errors:
foo(bar): unknown function in evalExpr: "foo"
tukeyAbove(1,2,3): missing time series
pearsonClosest(foo,bar,baz,quux): too many arguments
* Connection #0 to host 127.0.0.1 left intact
```

fixes #75