### PR TITLE
Make aliasSub compatible with \1 type backreferences.

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -531,6 +531,8 @@ var (
 	ErrTooManyArguments   = errors.New("too many arguments")
 )
 
+var backref = regexp.MustCompile(`\\(\d+)`)
+
 func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData) ([]*metricData, error) {
 
 	switch e.etype {
@@ -642,6 +644,8 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		if err != nil {
 			return nil, err
 		}
+
+		replace = backref.ReplaceAllString(replace, "$${$1}")
 
 		var results []*metricData
 

--- a/expr_test.go
+++ b/expr_test.go
@@ -890,6 +890,22 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "aliasSub",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1.TCP100"},
+					&expr{valStr: "^.*TCP(\\d+)", etype: etString},
+					&expr{valStr: "\\1", etype: etString},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric1.TCP100", 0, 1}: []*metricData{makeResponse("metric1.TCP100", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*metricData{makeResponse("100",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			&expr{
 				target: "derivative",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
I know this isn't 100% perfect (it doesn't account for the fact that the backslash might be backslashed) but it should work in practical situations, and eliminates the biggest cause of having to rewrite queries.

It rewrites \1 to ${1} and \10 to ${10} in the replacement template before passing it to ReplaceAllString.