### PR TITLE
Fix null pointer dereference in highest*

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -1733,7 +1733,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			}
 		}
 
-		results := make([]*metricData, n)
+		results := make([]*metricData, len(mh))
 
 		for len(mh) > 0 {
 			v := heap.Pop(&mh).(metricHeapElement)

--- a/expr.go
+++ b/expr.go
@@ -1329,7 +1329,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			}
 		}
 
-		results = make([]*metricData, n)
+		results = make([]*metricData, len(mh))
 
 		// results should be ordered ascending
 		for len(mh) > 0 {


### PR DESCRIPTION
In some cases, you have a series with all-null values in result.

Handle that case in a nicer way.