### PR TITLE
Add smoothedMovingAverage / smma(seriesList)

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -2237,6 +2237,51 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 		}
 		return results, nil
 
+	case "smma", "smoothedMovingAverage": // smma(seriesList)
+		arg, err := getSeriesArg(e.args[0], from, until, values)
+		if err != nil {
+			return nil, err
+		}
+
+		e.target = "smma"
+
+		// ugh, forEachSeriesDo does not handle arguments properly
+		var results []*metricData
+		for _, a := range arg {
+			var n float64
+			for _, miss := range a.IsAbsent {
+				if miss {
+					continue
+				}
+				n++
+			}
+			if n < 1 {
+				continue
+			}
+			alpha := 1 / n
+
+			name := fmt.Sprintf("smma(%s)", a.GetName())
+
+			r := *a
+			r.Name = proto.String(name)
+			r.Values = make([]float64, len(a.Values))
+			r.IsAbsent = make([]bool, len(a.Values))
+
+			smma := onlinestats.NewExpWeight(alpha)
+
+			for i, v := range a.Values {
+				if a.IsAbsent[i] {
+					r.IsAbsent[i] = true
+					continue
+				}
+
+				smma.Push(v)
+				r.Values[i] = smma.Mean()
+			}
+			results = append(results, &r)
+		}
+		return results, nil
+
 	case "pow": // pow(seriesList,factor)
 		arg, err := getSeriesArg(e.args[0], from, until, values)
 		if err != nil {

--- a/expr_test.go
+++ b/expr_test.go
@@ -1347,6 +1347,22 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "smma",
+				etype:  etFunc,
+				args: []*expr{
+					&expr{target: "metric1"},
+				},
+				argString: "metric1",
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric1", 0, 1}: []*metricData{makeResponse("metric1", []float64{0, 1, 1, math.NaN(), 1, 1, 1, 1, 1, 1, 1}, 1, now32)},
+			},
+			[]*metricData{
+				makeResponse("smma(metric1)", []float64{0, 0.9, 0.99, math.NaN(), 0.999, 0.9999, 0.99999, 0.999999, 0.9999999, 0.99999999, 0.999999999}, 1, now32),
+			},
+		},
+		{
+			&expr{
 				target: "grep",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
An exponentially weighted moving average (see: `ewma(seriesList, alpha)`) where the alpha
component is calculated as 1 / ( n : the number of defined points in
the series ).
## 

I had a private branch of ewma and smma from back in December that I
never merged. This is the smma portion, lightly translated to use the
same library as we did for ewma.
