### PR TITLE
Fix #126: send access logs to os.Stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JaderDias/carbonzipper/mlog"
 	pb "github.com/dgryski/carbonzipper/carbonzipperpb"
-	"github.com/dgryski/carbonzipper/mlog"
 	"github.com/dgryski/carbonzipper/mstats"
 
 	"github.com/JaderDias/go-httpaccesslog"
@@ -683,7 +683,7 @@ func main() {
 		logger.Logln(r.RequestURI, since.Nanoseconds()/int64(time.Millisecond), stats.zipperRequests)
 	}
 
-	accessLogger := httpaccesslog.AccessLogger{log.New(os.Stdout, "", 0)}
+	accessLogger := httpaccesslog.AccessLogger{log.New(mlog.GetOutput(), "", 0)}
 	http.HandleFunc("/render/", accessLogger.Handle(corsHandler(render)))
 	http.HandleFunc("/render", accessLogger.Handle(corsHandler(render)))
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"expvar"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
@@ -683,7 +682,7 @@ func main() {
 		logger.Logln(r.RequestURI, since.Nanoseconds()/int64(time.Millisecond), stats.zipperRequests)
 	}
 
-	accessLogger := httpaccesslog.AccessLogger{log.New(mlog.GetOutput(), "", 0)}
+	accessLogger := httpaccesslog.New(mlog.GetOutput())
 	http.HandleFunc("/render/", accessLogger.Handle(corsHandler(render)))
 	http.HandleFunc("/render", accessLogger.Handle(corsHandler(render)))
 


### PR DESCRIPTION
the format of the log is defined by Nginx

https://nginx.org/en/docs/http/ngx_http_log_module.html#access_log