### PR TITLE
Fix tukey

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -2792,18 +2792,18 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			if err != nil {
 				return nil, err
 			}
-			if beginInterval < 0 && (-1*beginInterval) < len(arg[0].Values) {
+			if beginInterval < 0 && (-1*beginInterval) < endInterval {
 				// negative intervals are everything preceding the last 'interval' points
-				endInterval = len(arg[0].Values) + beginInterval
+				endInterval += beginInterval
 				beginInterval = 0
-			} else if beginInterval > 0 && beginInterval < len(arg[0].Values) {
+			} else if beginInterval > 0 && beginInterval < endInterval {
 				// positive intervals are the last 'interval' points
-				beginInterval = len(arg[0].Values) - beginInterval
-				endInterval = len(arg[0].Values)
+				beginInterval = endInterval - beginInterval
+				//endInterval = len(arg[0].Values)
 			} else {
 				// zero -or- beyond the len() of the series ; will revert to whole range
 				beginInterval = 0
-				endInterval = len(arg[0].Values)
+				//endInterval = len(arg[0].Values)
 			}
 		}
 

--- a/expr.go
+++ b/expr.go
@@ -2793,7 +2793,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 				return nil, err
 			}
 			if beginInterval < 0 && (-1*beginInterval) < len(arg[0].Values) {
-				// negative intervals are everything except the last 'interval' points
+				// negative intervals are everything preceding the last 'interval' points
 				endInterval = len(arg[0].Values) + beginInterval
 				beginInterval = 0
 			} else if beginInterval > 0 && beginInterval < len(arg[0].Values) {
@@ -2801,7 +2801,7 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 				beginInterval = len(arg[0].Values) - beginInterval
 				endInterval = len(arg[0].Values)
 			} else {
-				// zero -or- beyond the len() of the series
+				// zero -or- beyond the len() of the series ; will revert to whole range
 				beginInterval = 0
 				endInterval = len(arg[0].Values)
 			}

--- a/expr.go
+++ b/expr.go
@@ -2774,6 +2774,8 @@ func evalExpr(e *expr, from, until int32, values map[metricRequest][]*metricData
 			return nil, errors.New("n must be larger or equal to 1")
 		}
 
+		//BUG(nnuss): interval is being determined here but not used later (found via ineffassign).
+		//            Expected behavior is to limit the tukey test to the recent data rather than the whole timespan.
 		var interval int
 		if len(e.args) >= 4 {
 			switch e.args[3].etype {

--- a/expr_test.go
+++ b/expr_test.go
@@ -3093,6 +3093,60 @@ func TestEvalMultipleReturns(t *testing.T) {
 				etype:  etFunc,
 				args: []*expr{
 					{target: "metric*"},
+					{val: 1.5, etype: etConst},
+					{val: 5, etype: etConst},
+					{val: -4, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: {
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28, 20, 20, 20, 20}, 1, now32),
+				},
+			},
+
+			"tukeyBelow",
+			map[string][]*metricData{
+				"metricA": {makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32)},
+				"metricE": {makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28, 20, 20, 20, 20}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "tukeyBelow",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric*"},
+					{val: 1.5, etype: etConst},
+					{val: 5, etype: etConst},
+					{valStr: "-4s", etype: etString},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: {
+					makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricB", []float64{20, 18, 21, 19, 20, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{19, 19, 21, 17, 23, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricD", []float64{18, 20, 22, 14, 26, 20, 20, 20, 20, 20}, 1, now32),
+					makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28, 20, 20, 20, 20}, 1, now32),
+				},
+			},
+
+			"tukeyBelow",
+			map[string][]*metricData{
+				"metricA": {makeResponse("metricA", []float64{21, 17, 20, 20, 10, 29, 20, 20, 20, 20}, 1, now32)},
+				"metricE": {makeResponse("metricE", []float64{17, 21, 8, 30, 18, 28, 20, 20, 20, 20}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "tukeyBelow",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric*"},
 					{val: 3, etype: etConst},
 					{val: 5, etype: etConst},
 				},

--- a/expr_test.go
+++ b/expr_test.go
@@ -3007,6 +3007,62 @@ func TestEvalMultipleReturns(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "tukeyAbove",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric*"},
+					{val: 1.5, etype: etConst},
+					{val: 5, etype: etConst},
+					{val: 6, etype: etConst},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: {
+					makeResponse("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 20, 20, 20, 20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{20, 20, 20, 20, 19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{20, 20, 20, 20, 18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{20, 20, 20, 20, 17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			"tukeyAbove(metric*, 1.5, 5, 6)",
+			map[string][]*metricData{
+				"metricA": {makeResponse("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32)},
+				"metricD": {makeResponse("metricD", []float64{20, 20, 20, 20, 18, 20, 22, 14, 26, 20}, 1, now32)},
+				"metricE": {makeResponse("metricE", []float64{20, 20, 20, 20, 17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
+		{
+			&expr{
+				target: "tukeyAbove",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric*"},
+					{val: 1.5, etype: etConst},
+					{val: 5, etype: etConst},
+					{valStr: "6s", etype: etString},
+				},
+			},
+			map[metricRequest][]*metricData{
+				metricRequest{"metric*", 0, 1}: {
+					makeResponse("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32),
+					makeResponse("metricB", []float64{20, 20, 20, 20, 20, 18, 21, 19, 20, 20}, 1, now32),
+					makeResponse("metricC", []float64{20, 20, 20, 20, 19, 19, 21, 17, 23, 20}, 1, now32),
+					makeResponse("metricD", []float64{20, 20, 20, 20, 18, 20, 22, 14, 26, 20}, 1, now32),
+					makeResponse("metricE", []float64{20, 20, 20, 20, 17, 21, 8, 30, 18, 28}, 1, now32),
+				},
+			},
+
+			`tukeyAbove(metric*, 1.5, 5, "6s")`,
+			map[string][]*metricData{
+				"metricA": {makeResponse("metricA", []float64{20, 20, 20, 20, 21, 17, 20, 20, 10, 29}, 1, now32)},
+				"metricD": {makeResponse("metricD", []float64{20, 20, 20, 20, 18, 20, 22, 14, 26, 20}, 1, now32)},
+				"metricE": {makeResponse("metricE", []float64{20, 20, 20, 20, 17, 21, 8, 30, 18, 28}, 1, now32)},
+			},
+		},
+		{
+			&expr{
 				target: "tukeyBelow",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
Fix interval handling in tukey{Above,Below} where it was found to be ignored.

Positive interval: test over the most recent `interval` datapoints.
Negative interval: test over all except the most recent `interval` datapoints.