### PR TITLE
Move all parsing/evaluation code to carbonapi/expr

### DIFF
--- a/expr/cairo.go
+++ b/expr/cairo.go
@@ -1,6 +1,6 @@
 // +build cairo
 
-package main
+package expr
 
 import (
 	"bufio"
@@ -438,7 +438,7 @@ func getStringArray(s string, def []string) []string {
 }
 
 func getFontItalic(s string) cairo.FontSlant {
-	if truthyBool(s) {
+	if TruthyBool(s) {
 		return cairo.FontSlantItalic
 	}
 
@@ -446,7 +446,7 @@ func getFontItalic(s string) cairo.FontSlant {
 }
 
 func getFontWeight(s string) cairo.FontWeight {
-	if truthyBool(s) {
+	if TruthyBool(s) {
 		return cairo.FontWeightBold
 	}
 
@@ -610,8 +610,8 @@ type Params struct {
 	yMinLeft    float64
 	yMinRight   float64
 
-	dataLeft  []*metricData
-	dataRight []*metricData
+	dataLeft  []*MetricData
+	dataRight []*MetricData
 
 	rightWidth  float64
 	rightDashed bool
@@ -639,7 +639,7 @@ type cairoSurfaceContext struct {
 	surface *cairo.ImageSurface
 }
 
-func marshalPNG(r *http.Request, results []*metricData) []byte {
+func MarshalPNG(r *http.Request, results []*MetricData) []byte {
 	var params = Params{
 		width:          getFloat64(r.FormValue("width"), 330),
 		height:         getFloat64(r.FormValue("height"), 250),
@@ -746,7 +746,7 @@ func marshalPNG(r *http.Request, results []*metricData) []byte {
 	return b.Bytes()
 }
 
-func drawGraph(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawGraph(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 	var minNumberOfPoints, maxNumberOfPoints int32
 	params.secondYAxis = false
 
@@ -966,7 +966,7 @@ func drawGraph(cr *cairoSurfaceContext, params *Params, results []*metricData) {
 	drawLines(cr, params, results)
 }
 
-func consolidateDataPoints(params *Params, results []*metricData) {
+func consolidateDataPoints(params *Params, results []*MetricData) {
 	numberOfPixels := params.area.xmax - params.area.xmin - (params.lineWidth + 1)
 	params.graphWidth = int(numberOfPixels)
 
@@ -989,13 +989,13 @@ func consolidateDataPoints(params *Params, results []*metricData) {
 	}
 }
 
-func setupTwoYAxes(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func setupTwoYAxes(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 
-	var Ldata []*metricData
-	var Rdata []*metricData
+	var Ldata []*MetricData
+	var Rdata []*MetricData
 
-	var seriesWithMissingValuesL []*metricData
-	var seriesWithMissingValuesR []*metricData
+	var seriesWithMissingValuesL []*MetricData
+	var seriesWithMissingValuesR []*MetricData
 
 	Ldata = params.dataLeft
 	Rdata = params.dataRight
@@ -1294,8 +1294,8 @@ func makeLabel(yValue, yStep, ySpan float64, yUnitSystem string) string {
 	}
 }
 
-func setupYAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) {
-	var seriesWithMissingValues []*metricData
+func setupYAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
+	var seriesWithMissingValues []*MetricData
 
 	var yMinValue, yMaxValue float64
 
@@ -1562,7 +1562,7 @@ func closest(number float64, neighbours []float64) float64 {
 	return closestNeighbor
 }
 
-func setupXAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func setupXAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 
 	/*
 	   if self.userTimeZone:
@@ -1595,7 +1595,7 @@ func setupXAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) 
 	params.xMajorGridStep = int32(params.xConf.majorGridUnit) * params.xConf.majorGridStep
 }
 
-func drawLabels(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawLabels(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 	if !params.hideYAxis {
 		drawYAxis(cr, params, results)
 	}
@@ -1604,7 +1604,7 @@ func drawLabels(cr *cairoSurfaceContext, params *Params, results []*metricData) 
 	}
 }
 
-func drawYAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawYAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 	var x float64
 	if params.secondYAxis {
 
@@ -1679,7 +1679,7 @@ func findXTimes(start int32, unit TimeUnit, step float64) (int32, int32) {
 	return int32(t.Unix()), int32(d / time.Second)
 }
 
-func drawXAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawXAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 
 	dt, xDelta := findXTimes(params.startTime, params.xConf.labelUnit, float64(params.xConf.labelStep))
 
@@ -1699,7 +1699,7 @@ func drawXAxis(cr *cairoSurfaceContext, params *Params, results []*metricData) {
 	}
 }
 
-func drawGridLines(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawGridLines(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 	// Horizontal grid lines
 	leftside := params.area.xmin
 	rightside := params.area.xmax
@@ -1901,7 +1901,7 @@ func getYCoord(params *Params, value float64, side YCoordSide) (y float64) {
 	return params.area.ymax - valueInPixels
 }
 
-func drawLines(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawLines(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 
 	linecap := "butt"
 	linejoin := "miter"
@@ -1925,13 +1925,13 @@ func drawLines(cr *cairoSurfaceContext, params *Params, results []*metricData) {
 
 	if !math.IsNaN(params.areaAlpha) {
 		alpha := params.areaAlpha
-		var strokeSeries []*metricData
+		var strokeSeries []*MetricData
 		for _, r := range results {
 			if r.stacked {
 				r.alpha = alpha
 				r.hasAlpha = true
 
-				newSeries := metricData{
+				newSeries := MetricData{
 					FetchResponse: pb.FetchResponse{
 						Name:      r.Name,
 						StopTime:  proto.Int32(r.GetStopTime()),
@@ -2111,7 +2111,7 @@ type SeriesLegend struct {
 	secondYAxis bool
 }
 
-func drawLegend(cr *cairoSurfaceContext, params *Params, results []*metricData) {
+func drawLegend(cr *cairoSurfaceContext, params *Params, results []*MetricData) {
 	const (
 		padding = 5
 	)
@@ -2445,7 +2445,7 @@ func hexToRGBA(h string) color.RGBA {
 	return color.RGBA{r, g, b, alpha}
 }
 
-type ByStacked []*metricData
+type ByStacked []*MetricData
 
 func (b ByStacked) Len() int { return len(b) }
 

--- a/expr/graphutil.go
+++ b/expr/graphutil.go
@@ -1,4 +1,4 @@
-package main
+package expr
 
 import (
 	"image/color"

--- a/expr/helper.go
+++ b/expr/helper.go
@@ -1,57 +1,14 @@
-package main
+package expr
 
 import (
 	"errors"
 	"strconv"
-	"strings"
-	"time"
 )
 
 var errUnknownTimeUnits = errors.New("unknown time units")
 
-// dateParamToEpoch turns a passed string parameter into a unix epoch
-func dateParamToEpoch(s string, d int64) int32 {
-
-	if s == "" {
-		// return the default if nothing was passed
-		return int32(d)
-	}
-
-	// relative timestamp
-	if s[0] == '-' {
-
-		offset, err := intervalString(s, -1)
-		if err != nil {
-			return int32(d)
-		}
-
-		return int32(timeNow().Add(time.Duration(offset) * time.Second).Unix())
-	}
-
-	if s == "now" {
-		return int32(timeNow().Unix())
-	}
-
-	sint, err := strconv.Atoi(s)
-	if err == nil && len(s) > 8 {
-		return int32(sint) // We got a timestamp so returning it
-	}
-
-	if strings.Contains(s, "_") {
-		s = strings.Replace(s, "_", " ", 1) // Go can't parse _ in date strings
-	}
-
-	for _, format := range timeFormats {
-		t, err := time.ParseInLocation(format, s, defaultTimeZone)
-		if err == nil {
-			return int32(t.Unix())
-		}
-	}
-	return int32(d)
-}
-
-// intervalString converts a sign and string into a number of seconds
-func intervalString(s string, defaultSign int) (int32, error) {
+// IntervalString converts a sign and string into a number of seconds
+func IntervalString(s string, defaultSign int) (int32, error) {
 
 	sign := defaultSign
 
@@ -110,7 +67,7 @@ func intervalString(s string, defaultSign int) (int32, error) {
 	return totalInterval, nil
 }
 
-func truthyBool(s string) bool {
+func TruthyBool(s string) bool {
 	switch s {
 	case "", "0", "false", "False", "no", "No":
 		return false

--- a/expr/helper_test.go
+++ b/expr/helper_test.go
@@ -1,0 +1,52 @@
+package expr
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInterval(t *testing.T) {
+
+	var tests = []struct {
+		t       string
+		seconds int32
+		sign    int
+	}{
+		{"1s", 1, 1},
+		{"2d", 2 * 60 * 60 * 24, 1},
+		{"10hours", 60 * 60 * 10, 1},
+		{"7d13h45min21s", 7*24*60*60 + 13*60*60 + 45*60 + 21, 1},
+		{"01hours", 60 * 60 * 1, 1},
+		{"2d2d", 4 * 60 * 60 * 24, 1},
+
+		{"1s", -1, -1},
+		{"+2d", 2 * 60 * 60 * 24, -1},
+		{"-10hours", -60 * 60 * 10, -1},
+		{"-360h2min", -360*60*60 - 2*60, -1},
+	}
+
+	for _, tt := range tests {
+		if secs, _ := IntervalString(tt.t, tt.sign); secs != tt.seconds {
+			t.Errorf("intervalString(%q)=%d, want %d\n", tt.t, secs, tt.seconds)
+		}
+	}
+
+	var exceptTests = []struct {
+		t       string
+		seconds int32
+		err     string
+		sign    int
+	}{
+		{"10m10s", 0, "unknown time units", 1},
+		{"10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000y", 0, "value out of range", 1},
+	}
+	for _, tt := range exceptTests {
+		secs, err := IntervalString(tt.t, tt.sign)
+		if secs != tt.seconds {
+			t.Errorf("intervalString(%q)=%d, want %d\n", tt.t, secs, tt.seconds)
+		}
+		if !strings.Contains(err.Error(), tt.err) {
+			t.Errorf("Error of intervalString(%q)=%v, expected to contain %v\n", tt.t, err.Error(), tt.err)
+		}
+	}
+}

--- a/expr/metricdata.go
+++ b/expr/metricdata.go
@@ -1,4 +1,4 @@
-package main
+package expr
 
 import (
 	"bytes"
@@ -10,7 +10,7 @@ import (
 	pickle "github.com/kisielk/og-rek"
 )
 
-type metricData struct {
+type MetricData struct {
 	pb.FetchResponse
 
 	// extra options
@@ -31,7 +31,7 @@ type metricData struct {
 	aggregateFunction func([]float64, []bool) float64
 }
 
-func marshalCSV(results []*metricData) []byte {
+func MarshalCSV(results []*MetricData) []byte {
 
 	var b []byte
 
@@ -56,7 +56,7 @@ func marshalCSV(results []*metricData) []byte {
 	return b
 }
 
-func marshalJSON(results []*metricData) []byte {
+func MarshalJSON(results []*MetricData) []byte {
 
 	var b []byte
 	b = append(b, '[')
@@ -109,7 +109,7 @@ func marshalJSON(results []*metricData) []byte {
 	return b
 }
 
-func marshalPickle(results []*metricData) []byte {
+func MarshalPickle(results []*MetricData) []byte {
 
 	var p []map[string]interface{}
 
@@ -140,7 +140,7 @@ func marshalPickle(results []*metricData) []byte {
 	return buf.Bytes()
 }
 
-func marshalProtobuf(results []*metricData) ([]byte, error) {
+func MarshalProtobuf(results []*MetricData) ([]byte, error) {
 	response := pb.MultiFetchResponse{}
 	for _, metric := range results {
 		response.Metrics = append(response.Metrics, &((*metric).FetchResponse))
@@ -153,7 +153,7 @@ func marshalProtobuf(results []*metricData) ([]byte, error) {
 	return b, nil
 }
 
-func marshalRaw(results []*metricData) []byte {
+func MarshalRaw(results []*MetricData) []byte {
 
 	var b []byte
 
@@ -187,7 +187,7 @@ func marshalRaw(results []*metricData) []byte {
 	return b
 }
 
-func (r *metricData) AggregatedTimeStep() int32 {
+func (r *MetricData) AggregatedTimeStep() int32 {
 	if r.valuesPerPoint == 1 || r.valuesPerPoint == 0 {
 		return r.GetStepTime()
 	}
@@ -195,7 +195,7 @@ func (r *metricData) AggregatedTimeStep() int32 {
 	return r.GetStepTime() * int32(r.valuesPerPoint)
 }
 
-func (r *metricData) AggregatedValues() []float64 {
+func (r *MetricData) AggregatedValues() []float64 {
 	if r.aggregatedValues != nil {
 		return r.aggregatedValues
 	}

--- a/expr/metricdata_test.go
+++ b/expr/metricdata_test.go
@@ -1,67 +1,20 @@
-package main
+package expr
 
 import (
 	"bytes"
 	"math"
 	"math/rand"
-	"strings"
 	"testing"
 )
-
-func TestInterval(t *testing.T) {
-
-	var tests = []struct {
-		t       string
-		seconds int32
-		sign    int
-	}{
-		{"1s", 1, 1},
-		{"2d", 2 * 60 * 60 * 24, 1},
-		{"10hours", 60 * 60 * 10, 1},
-		{"7d13h45min21s", 7*24*60*60 + 13*60*60 + 45*60 + 21, 1},
-		{"01hours", 60 * 60 * 1, 1},
-		{"2d2d", 4 * 60 * 60 * 24, 1},
-
-		{"1s", -1, -1},
-		{"+2d", 2 * 60 * 60 * 24, -1},
-		{"-10hours", -60 * 60 * 10, -1},
-		{"-360h2min", -360*60*60 - 2*60, -1},
-	}
-
-	for _, tt := range tests {
-		if secs, _ := intervalString(tt.t, tt.sign); secs != tt.seconds {
-			t.Errorf("intervalString(%q)=%d, want %d\n", tt.t, secs, tt.seconds)
-		}
-	}
-
-	var exceptTests = []struct {
-		t       string
-		seconds int32
-		err     string
-		sign    int
-	}{
-		{"10m10s", 0, "unknown time units", 1},
-		{"10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000y", 0, "value out of range", 1},
-	}
-	for _, tt := range exceptTests {
-		secs, err := intervalString(tt.t, tt.sign)
-		if secs != tt.seconds {
-			t.Errorf("intervalString(%q)=%d, want %d\n", tt.t, secs, tt.seconds)
-		}
-		if !strings.Contains(err.Error(), tt.err) {
-			t.Errorf("Error of intervalString(%q)=%v, expected to contain %v\n", tt.t, err.Error(), tt.err)
-		}
-	}
-}
 
 func TestJSONResponse(t *testing.T) {
 
 	tests := []struct {
-		results []*metricData
+		results []*MetricData
 		out     []byte
 	}{
 		{
-			[]*metricData{
+			[]*MetricData{
 				makeResponse("metric1", []float64{1, 1.5, 2.25, math.NaN()}, 100, 100),
 				makeResponse("metric2", []float64{2, 2.5, 3.25, 4, 5}, 100, 100),
 			},
@@ -70,7 +23,7 @@ func TestJSONResponse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		b := marshalJSON(tt.results)
+		b := MarshalJSON(tt.results)
 		if !bytes.Equal(b, tt.out) {
 			t.Errorf("marshalJSON(%+v)=%+v, want %+v", tt.results, string(b), string(tt.out))
 		}
@@ -80,11 +33,11 @@ func TestJSONResponse(t *testing.T) {
 func TestRawResponse(t *testing.T) {
 
 	tests := []struct {
-		results []*metricData
+		results []*MetricData
 		out     []byte
 	}{
 		{
-			[]*metricData{
+			[]*MetricData{
 				makeResponse("metric1", []float64{1, 1.5, 2.25, math.NaN()}, 100, 100),
 				makeResponse("metric2", []float64{2, 2.5, 3.25, 4, 5}, 100, 100),
 			},
@@ -93,7 +46,7 @@ func TestRawResponse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		b := marshalRaw(tt.results)
+		b := MarshalRaw(tt.results)
 		if !bytes.Equal(b, tt.out) {
 			t.Errorf("marshalRaw(%+v)=%+v, want %+v", tt.results, string(b), string(tt.out))
 		}
@@ -111,13 +64,13 @@ func getData(rangeSize int) []float64 {
 }
 
 func BenchmarkMarshalJSON(b *testing.B) {
-	data := []*metricData{
+	data := []*MetricData{
 		makeResponse("metric1", getData(10000), 100, 100),
 		makeResponse("metric2", getData(100000), 100, 100),
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = marshalJSON(data)
+		_ = MarshalJSON(data)
 	}
 }

--- a/expr/png.go
+++ b/expr/png.go
@@ -1,0 +1,9 @@
+// +build !cairo
+
+package expr
+
+import "net/http"
+
+func MarshalPNG(r *http.Request, results []*MetricData) []byte {
+	return nil
+}

--- a/expr/sort_test.go
+++ b/expr/sort_test.go
@@ -1,4 +1,4 @@
-package main
+package expr
 
 import (
 	"testing"
@@ -15,12 +15,12 @@ func TestSortMetrics(t *testing.T) {
 		fourth = "a.fourth.c.d"
 	)
 	tests := []struct {
-		metrics []*metricData
-		mfetch  metricRequest
-		sorted  []*metricData
+		metrics []*MetricData
+		mfetch  MetricRequest
+		sorted  []*MetricData
 	}{
 		{
-			[]*metricData{
+			[]*MetricData{
 				//NOTE(nnuss): keep these lines lexically sorted ;)
 				makeResponse(bronze, []float64{}, 1, 0),
 				makeResponse(first, []float64{}, 1, 0),
@@ -30,12 +30,12 @@ func TestSortMetrics(t *testing.T) {
 				makeResponse(silver, []float64{}, 1, 0),
 				makeResponse(third, []float64{}, 1, 0),
 			},
-			metricRequest{
-				metric: "a.{first,second,third,fourth}.c.d",
-				from:   0,
-				until:  1,
+			MetricRequest{
+				Metric: "a.{first,second,third,fourth}.c.d",
+				From:   0,
+				Until:  1,
 			},
-			[]*metricData{
+			[]*MetricData{
 				//These are in the brace appearance order
 				makeResponse(first, []float64{}, 1, 0),
 				makeResponse(second, []float64{}, 1, 0),
@@ -53,7 +53,7 @@ func TestSortMetrics(t *testing.T) {
 		if len(test.metrics) != len(test.sorted) {
 			t.Skipf("Error in test %d : length mismatch %d vs. %d", i, len(test.metrics), len(test.sorted))
 		}
-		sortMetrics(test.metrics, test.mfetch)
+		SortMetrics(test.metrics, test.mfetch)
 		for i := range test.metrics {
 			if *test.metrics[i].Name != *test.sorted[i].Name {
 				t.Errorf("[%d] Expected %q but have %q", i, *test.sorted[i].Name, *test.metrics[i].Name)

--- a/png.go
+++ b/png.go
@@ -1,9 +1,0 @@
-// +build !cairo
-
-package main
-
-import "net/http"
-
-func marshalPNG(r *http.Request, results []*metricData) []byte {
-	return nil
-}

--- a/zipper.go
+++ b/zipper.go
@@ -3,11 +3,13 @@ package main
 import (
 	"errors"
 	"fmt"
-	pb "github.com/dgryski/carbonzipper/carbonzipperpb"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/dgryski/carbonapi/expr"
+	pb "github.com/dgryski/carbonzipper/carbonzipperpb"
 )
 
 var errNoMetrics = errors.New("no metrics")
@@ -75,7 +77,7 @@ func (z zipper) Passthrough(metric string) ([]byte, error) {
 	return body, nil
 }
 
-func (z zipper) Render(metric string, from, until int32) (metricData, error) {
+func (z zipper) Render(metric string, from, until int32) (expr.MetricData, error) {
 
 	u, _ := url.Parse(z.z + "/render/")
 
@@ -89,14 +91,14 @@ func (z zipper) Render(metric string, from, until int32) (metricData, error) {
 	var pbresp pb.MultiFetchResponse
 	err := z.get("Render", u, &pbresp)
 	if err != nil {
-		return metricData{}, err
+		return expr.MetricData{}, err
 	}
 
 	if m := pbresp.Metrics; len(m) == 0 {
-		return metricData{}, errNoMetrics
+		return expr.MetricData{}, errNoMetrics
 	}
 
-	mdata := metricData{FetchResponse: *pbresp.Metrics[0]}
+	mdata := expr.MetricData{FetchResponse: *pbresp.Metrics[0]}
 
 	return mdata, nil
 }


### PR DESCRIPTION
This is a major change and will require rebasing all outstanding commits.

It makes the expression parsing and evaluation code its own package so that it can be reused.

It also means that the carbonapi main package now only contains the http server logic.

Overall I think this is a good change.

I change just enough of the packages so that it would compile.  It's otherwise untested.  This also means that the API that we exposed to the server half is exactly the set of APIs that are exposed.  For this to be more generally useful as a standalone package, we will probably need to do more tweaking of exactly what is exported.  We'll also need a lot more documentation fixes.