### PR TITLE
Fix a stupid oversight in AggregatedValues

### DIFF
--- a/expr/metricdata.go
+++ b/expr/metricdata.go
@@ -227,8 +227,8 @@ func (r *MetricData) AggregatedTimeStep() int32 {
 }
 
 func (r *MetricData) AggregatedValues() []float64 {
-	if r.aggregatedValues != nil {
-		return r.aggregatedValues
+	if r.aggregatedValues == nil {
+		r.AggregateValues()
 	}
 	return r.aggregatedValues
 }


### PR DESCRIPTION
Both branches of the if are the same, and neither one computes
aggregations! This only works because MarshalJSON calls AggregatedAbsent
before AggregatedValues, and I didn't make the same mistake there.
Cairo, on the other hand, is probably completely broken.