### PR TITLE
README.md: OSX Build Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ OSX Build Notes
 Some additional steps may be needed to build carbonapi with cairo rendering on MacOSX.
 
 Install cairo:
-`$ brew install cairo --with-x11`
 
-Set `PKG_CONFIG_PATH` and `-tags cairo` when building
-`$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig go test -v -tags cairo`
+$ brew install Caskroom/cask/xquartz
+
+$ brew install cairo --with-x11
+
+Set `PKG_CONFIG_PATH` and `-tags cairo` when building:
+
+$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig go test -v -tags cairo
 
 Acknowledgement
 ---------------

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ or if the GRAPHITEHOST/GRAPHITEPORT environment variables are found.
 
 Request data will be stored in memory (default) or in memcache.
 
+OSX Build Notes
+---------------
+Some additional steps may be needed to build carbonapi with cairo rendering on MacOSX.
+
+Install cairo:
+`$ brew install cairo --with-x11`
+
+Set `PKG_CONFIG_PATH` and `-tags cairo` when building
+`$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig go test -v -tags cairo`
+
 Acknowledgement
 ---------------
 This program was originally developed for Booking.com.  With approval

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ brew install cairo --with-x11
 
 Set `PKG_CONFIG_PATH` and `-tags cairo` when building:
 
-$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig go test -v -tags cairo
+$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig go build -v -tags cairo
 
 Acknowledgement
 ---------------


### PR DESCRIPTION
Notes for users wishing to build carbonapi with cairo rendering support on Mac OSX which commonly lacks cairo and appropriately set PKG_CONFIG_PATH.