### PR TITLE
Add cactiStyle function with 'si' support for #156

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -2081,6 +2081,208 @@ func TestEvalExpression(t *testing.T) {
 			[]*MetricData{makeResponse("removeAbovePercentile(metric1, 50)",
 				[]float64{1, 2, -1, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{math.NaN(), 20531.733333333334, 20196.4, 17925.333333333332, 20950.4, 35168.13333333333, 19965.866666666665, 24556.4, 22266.4, 58039.86666666667}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 58k Max: 58k Min: 18k",
+					[]float64{math.NaN(), 20531.733333333334, 20196.4, 17925.333333333332, 20950.4, 35168.13333333333, 19965.866666666665, 24556.4, 22266.4, 58039.86666666667}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 1 Max: 1 Min: 1",
+					[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+					{valStr: "carrot", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 1 carrot Max: 1 carrot Min: 1 carrot",
+					[]float64{1.432729, 1.434207, 1.404762, 1.414609, 1.399159, 1.411343, 1.406217, 1.407123, 1.392078, math.NaN()}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{math.NaN(), 88364212.53333333, 79008410.93333334, 80312920.0, 69860465.2, 83876830.0, 80399148.8, 90481297.46666667, 79628113.73333333, math.NaN()}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 80M Max: 90M Min: 70M",
+					[]float64{math.NaN(), 88364212.53333333, 79008410.93333334, 80312920.0, 69860465.2, 83876830.0, 80399148.8, 90481297.46666667, 79628113.73333333, math.NaN()}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{1000}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 1k Max: 1k Min: 1k",
+					[]float64{1000}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{1000}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 1000 Max: 1000 Min: 1000",
+					[]float64{1000}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+				namedArgs: map[string]*expr{
+					"units": {etype: etString, valStr: "apples"},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{10}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 10 apples Max: 10 apples Min: 10 apples",
+					[]float64{10}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, math.NaN()}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 240 Max: 240 Min: 240",
+					[]float64{240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, 240.0, math.NaN()}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{-1.0, -2.0, -1.0, -3.0, -1.0, -1.0, -0.0, -0.0, -0.0}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: 0 Max: 0 Min: -3",
+					[]float64{-1.0, -2.0, -1.0, -3.0, -1.0, -1.0, -0.0, -0.0, -0.0}, 1, now32),
+			},
+		},
+		{
+			&expr{
+				target: "cactiStyle",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "si", etype: etString},
+				},
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {
+					makeResponse("metric1",
+						[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				},
+			},
+			[]*MetricData{
+				makeResponse("metric1 Current: NaN Max: NaN Min: NaN",
+					[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds a cactiStyle function, supporting:

- no unit standardisation or 'si' unit standardisation
- arbitrary unit postfixing

It does not support:

- 'binary' unit standardisation (this should be easy enough to add, but I don't really have test examples for it)

This has been 'roughly' tested, using some internal pre-existing render parameters. Further testing needs to take place, to ensure there are no rounding or other not-so-obvious issues present.

TODO:

- Implement the 'binary' unit standardisation?
- Fix the unit tests

Opening a PR for the purposes of feedback.