### PR TITLE
png: yMax and yMin shouldn't be inf

### DIFF
--- a/expr/cairo.go
+++ b/expr/cairo.go
@@ -1391,10 +1391,10 @@ func setupYAxis(cr *cairoSurfaceContext, params *Params, results []*MetricData) 
 				if absent[i] {
 					continue
 				}
-				if math.IsNaN(yMinValue) || yMinValue > v {
+				if !math.IsInf(v, 0) && (math.IsNaN(yMinValue) || yMinValue > v) {
 					yMinValue = v
 				}
-				if math.IsNaN(yMaxValue) || yMaxValue < v {
+				if !math.IsInf(v, 0) && (math.IsNaN(yMaxValue) || yMaxValue < v) {
 					yMaxValue = v
 				}
 			}


### PR DESCRIPTION
Ignore infinity values while computing yMin and yMax

Otherwise png rendering is broken.