### PR TITLE
Add more holtWinters functions

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -138,10 +138,10 @@ highestAverage(seriesList, n)                                             |  0.9
 highestCurrent(seriesList, n)                                             |  0.9.9  | Supported
 highestMax(seriesList, n)                                                 |  0.9.9  | Supported
 hitcount(seriesList, intervalString, alignToInterval=False)               |  0.9.10 | Supported
-holtWintersAberration(seriesList, delta=3)                                |  0.9.10 | [#66](https://github.com/dgryski/carbonapi/issues/66)
+holtWintersAberration(seriesList, delta=3)                                |  0.9.10 | Supported
 holtWintersConfidenceArea(seriesList, delta=3)                            |  0.9.10 | [#66](https://github.com/dgryski/carbonapi/issues/66)
-holtWintersConfidenceBands(seriesList, delta=3)                           |  0.9.10 | [#66](https://github.com/dgryski/carbonapi/issues/66)
-holtWintersForecast(seriesList)                                           |  0.9.10 | Supported - but see: [#66](https://github.com/dgryski/carbonapi/issues/66)
+holtWintersConfidenceBands(seriesList, delta=3)                           |  0.9.10 | Supported
+holtWintersForecast(seriesList)                                           |  0.9.10 | Supported
 identity(name)                                                            |  0.9.14 |
 integral(seriesList)                                                      |  0.9.9  | Supported
 integralByInterval(seriesList, intervalUnit)                              |  latest |

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -3123,7 +3123,7 @@ func EvalExpr(e *expr, from, until int32, values map[MetricRequest][]*MetricData
 		for _, arg := range args {
 			stepTime := arg.GetStepTime()
 
-			predictions := holtWintersAnalysis(arg.Values, stepTime)
+			predictions, _ := holtWintersAnalysis(arg.Values, stepTime)
 
 			windowPoints := 7 * 86400 / stepTime
 			predictionsOfInterest := predictions[windowPoints:]

--- a/expr/hw.go
+++ b/expr/hw.go
@@ -17,10 +17,16 @@ func holtWintersSlope(beta, intercept, lastIntercept, lastSlope float64) float64
 
 func holtWintersSeasonal(gamma, actual, intercept, lastSeason float64) float64 {
 	return gamma*(actual-intercept) + (1-gamma)*lastSeason
-
 }
 
-func holtWintersAnalysis(series []float64, step int32) []float64 {
+func holtWintersDeviation(gamma, actual, prediction, lastSeasonalDev float64) float64 {
+	if math.IsNaN(prediction) {
+		prediction = 0
+	}
+	return gamma*math.Abs(actual-prediction) + (1-gamma)*lastSeasonalDev
+}
+
+func holtWintersAnalysis(series []float64, step int32) ([]float64, []float64) {
 	const (
 		alpha = 0.1
 		beta  = 0.0035
@@ -35,12 +41,21 @@ func holtWintersAnalysis(series []float64, step int32) []float64 {
 		slopes      []float64
 		seasonals   []float64
 		predictions []float64
+		deviations  []float64
 	)
 
 	getLastSeasonal := func(i int) float64 {
 		j := i - seasonLength
 		if j >= 0 {
 			return seasonals[j]
+		}
+		return 0
+	}
+
+	getLastDeviation := func(i int) float64 {
+		j := i - seasonLength
+		if j >= 0 {
+			return deviations[j]
 		}
 		return 0
 	}
@@ -55,6 +70,7 @@ func holtWintersAnalysis(series []float64, step int32) []float64 {
 			slopes = append(slopes, 0)
 			seasonals = append(seasonals, 0)
 			predictions = append(predictions, nextPred)
+			deviations = append(deviations, 0)
 			nextPred = math.NaN()
 			continue
 		}
@@ -80,17 +96,20 @@ func holtWintersAnalysis(series []float64, step int32) []float64 {
 
 		lastSeasonal := getLastSeasonal(i)
 		nextLastSeasonal := getLastSeasonal(i + 1)
+		lastSeasonalDev := getLastDeviation(i)
 
 		intercept := holtWintersIntercept(alpha, actual, lastSeasonal, lastIntercept, lastSlope)
 		slope := holtWintersSlope(beta, intercept, lastIntercept, lastSlope)
 		seasonal := holtWintersSeasonal(gamma, actual, intercept, lastSeasonal)
 		nextPred = intercept + slope + nextLastSeasonal
+		deviation := holtWintersDeviation(gamma, actual, prediction, lastSeasonalDev)
 
 		intercepts = append(intercepts, intercept)
 		slopes = append(slopes, slope)
 		seasonals = append(seasonals, seasonal)
 		predictions = append(predictions, prediction)
+		deviations = append(deviations, deviation)
 	}
 
-	return predictions
+	return predictions, deviations
 }

--- a/expr/hw.go
+++ b/expr/hw.go
@@ -113,3 +113,27 @@ func holtWintersAnalysis(series []float64, step int32) ([]float64, []float64) {
 
 	return predictions, deviations
 }
+
+func holtWintersConfidenceBands(series []float64, step int32, delta float64) ([]float64, []float64) {
+	var lowerBand, upperBand []float64
+
+	predictions, deviations := holtWintersAnalysis(series, step)
+
+	windowPoints := 7 * 86400 / step
+
+	predictionsOfInterest := predictions[windowPoints:]
+	deviationsOfInterest := deviations[windowPoints:]
+
+	for i, _ := range predictionsOfInterest {
+		if math.IsNaN(predictionsOfInterest[i]) || math.IsNaN(deviationsOfInterest[i]) {
+			lowerBand = append(lowerBand, math.NaN())
+			upperBand = append(upperBand, math.NaN())
+		} else {
+			scaledDeviation := delta * deviationsOfInterest[i]
+			lowerBand = append(lowerBand, predictionsOfInterest[i]-scaledDeviation)
+			upperBand = append(upperBand, predictionsOfInterest[i]+scaledDeviation)
+		}
+	}
+
+	return lowerBand, upperBand
+}


### PR DESCRIPTION
This adds `holtWintersConfidenceBands(seriesList, delta=3)` and `holtWintersAberration(seriesList, delta=3)` functions, of use in anomaly detection.

The only one missing is `holtWintersConfidenceArea`. I think that this is implementable — it needs to be rewritten in `Metrics()` to an `areaBetween` that takes `holtWintersConfidenceBands` as `seriesList`. But that's a little subtle for me, and I don't use the cairo renderer anyway, so I leave it up to someone else.

Mostly completes #66.