### PR TITLE
add expr lowPass to use with fft and ifft

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -536,6 +536,21 @@ func TestEvalExpression(t *testing.T) {
 		},
 		{
 			&expr{
+				target: "lowPass",
+				etype:  etFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{val: 40, etype: etConst},
+				},
+				argString: "metric1,40",
+			},
+			map[MetricRequest][]*MetricData{
+				MetricRequest{"metric1", 0, 1}: {makeResponse("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 1, now32)},
+			},
+			[]*MetricData{makeResponse("lowPass(metric1,40)", []float64{0, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 8, 9}, 1, now32)},
+		},
+		{
+			&expr{
 				target: "countSeries",
 				etype:  etFunc,
 				args: []*expr{


### PR DESCRIPTION
Once we use 'fft' there are several operations we can perform on its
result before converting it back to a time series with 'ifft'.

'removeBelowValue' is one example, but another important function is
the low pass filter. This commit is a version of such a filter that
can operate directly on the output of the 'fft' as follows:

    ifft(lowPass(fft(metric1,'abs'),0.2),fft(metric1,'phase'))