### PR TITLE
expr: allow '<' and '>' in metric names

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -259,7 +259,8 @@ func isNameChar(r byte) bool {
 		'A' <= r && r <= 'Z' ||
 		'0' <= r && r <= '9' ||
 		r == '.' || r == '_' || r == '-' || r == '*' || r == '?' || r == ':' ||
-		r == '[' || r == ']'
+		r == '[' || r == ']' ||
+		r == '<' || r == '>'
 }
 
 func isDigit(r byte) bool {


### PR DESCRIPTION
This enables support for quoted text searches in carbonsearch,
introduced in
https://github.com/kanatohodets/carbonsearch/commit/6d61f5290b52105137b4f8224c8883d8cbdc909d.

Previously using '<' or '>' was a parse error in render.