### PR TITLE
Adding ProxyHeaders to the list of http hanlers

### DIFF
--- a/main.go
+++ b/main.go
@@ -783,6 +783,7 @@ func main() {
 	logger.Logln("listening on port", *port)
 	handler := handlers.CompressHandler(r)
 	handler = handlers.CORS()(handler)
+	handler = handlers.ProxyHeaders(handler)
 	handler = handlers.CombinedLoggingHandler(mlog.GetOutput(), handler)
 
 	err := gracehttp.Serve(&http.Server{


### PR DESCRIPTION
When traffic to carbonapi passing load balancer or any kind of reverse
proxy we cannot see actual client IP in the logs.

This commit trying to address this issue adding handler which inspects
common reverse proxy headers and sets the corresponding fields in the
HTTP request struct. These are X-Forwarded-For and X-Real-IP for the
remote (client) IP address.