### PR TITLE
Extend legendValues support

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -1018,12 +1018,13 @@ func TestEvalExpression(t *testing.T) {
 				args: []*expr{
 					{target: "metric1"},
 					{valStr: "sum", etype: etString},
+					{valStr: "avg", etype: etString},
 				},
 			},
 			map[MetricRequest][]*MetricData{
 				{"metric1", 0, 1}: {makeResponse("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			[]*MetricData{makeResponse("metric1 (sum: 15.000000)",
+			[]*MetricData{makeResponse("metric1 (sum: 15.000000) (avg: 3.000000)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 		{


### PR DESCRIPTION
This PR adds support for multiple [legendValues](http://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.legendValue) in a single call, per the official Python implementation. 

It also adds the case 'total' as an extra name for 'sum' in summarizeValues.

I've minimally extended expr_test.go, please let me know if I need to modify the tests in a specific fashion. 